### PR TITLE
Rename project to thoughtbelt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Suspenders CLI
+# thoughtbelt CLI
 
 Perform project setup and redundant tasks without your pants falling down!
 
@@ -6,17 +6,19 @@ This project is still in very early stages. Track this project [in Trello](https
 
 ## Usage
 
+This package is not yet available on NPM. For now, you can run the CLI locally Only the scaffolding is in place right now.
+
 Ensure you have a recent version of Node.js installed, then install dependencies:
 
 ```
 yarn install
 ```
 
-Only the scaffolding is in place right now. Some example commands:
+Then, run some commands, eg.:
 
 ```
-> yarn suspenders react-native eslint
-> yarn suspenders react-native prettier
+> bin/belt eslint
+> bin/belt prettier
 ```
 
 ## Contributing
@@ -25,15 +27,14 @@ See the [CONTRIBUTING](./CONTRIBUTING.md) document. Thank you, [contributors](ht
 
 ## License
 
-Suspenders CLI is Copyright © 2023 Stephen Hanson and thoughtbot. It is free
-software, and may be redistributed under the terms specified in the
-[LICENSE](/LICENSE) file.
+thoughtbelt is Copyright © 2023 thoughtbot. It is free software, and may be
+redistributed under the terms specified in the [LICENSE](/LICENSE) file.
 
 ### About thoughtbot
 
 <img src="https://thoughtbot.com/thoughtbot-logo-for-readmes.svg" width="375" />
 
-Suspenders CLI is maintained and funded by thoughtbot, inc.
+thoughtbelt is maintained and funded by thoughtbot, inc.
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.
 
 We love open source software! See [our other projects][community] or

--- a/bin/belt
+++ b/bin/belt
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+node -r ts-node/register ./react-native/react-native.ts "$@"

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import { program } from "commander";
 
 program
-  .name("suspenders")
+  .name("thoughtbelt")
   .description(
     "Perform project setup and redundant tasks without your pants falling down!"
   )

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "suspenders-cli",
+  "name": "thoughtbelt",
   "version": "1.0.0",
   "description": "Monorepo for project bootstrapping CLIs",
   "main": "index.js",
   "scripts": {
-    "suspenders": "node -r ts-node/register ./index.ts",
+    "belt": "bin/belt",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Stephen Hanson",

--- a/react-native/react-native.ts
+++ b/react-native/react-native.ts
@@ -3,8 +3,11 @@ import { program } from "commander";
 console.log("React Native 🎉");
 
 program
-  .description('Perform React Native and Expo setup and redundant tasks without your pants falling down!')
+  .name("thoughtbelt")
+  .description(
+    "Perform React Native and Expo setup and redundant tasks without your pants falling down!"
+  )
   .command("eslint", "Configure ESLint", { executableFile: "eslint.ts" })
-  .command("prettier", "Configure Prettier", { executableFile: "prettier.ts" });
-
-program.parse();
+  .command("prettier", "Configure Prettier", { executableFile: "prettier.ts" })
+  .showHelpAfterError()
+  .parse();


### PR DESCRIPTION
* CLI is invoked with `belt` instead of `thoughtbelt` because shorter to type
* CLI now invokes the 'react-native' command by default, no need to run eg. 'belt react-native eslint'