### PR TITLE
Minor update to tsconfig.json

### DIFF
--- a/src/commands/templates/tsconfig.json.eta
+++ b/src/commands/templates/tsconfig.json.eta
@@ -21,7 +21,7 @@
       "assets/*": ["assets/*"]
     }
   },
-  "include": ["src/**/*", "*.js", ".*.js"],
+  "include": ["src/**/*", "*.js", ".*.js", "*.ts", "*.tsx"],
   "exclude": ["node_modules"],
   <% if(it.expo) { %>
     "extends":  "expo/tsconfig.base"


### PR DESCRIPTION
I noticed the `tsconfig.json` `include` paths don't include root-level `App.tsx`, which a new Expo project comes with out of the box. This PR adds root level `*.ts` and `*.tsx` so those files will get TypeScript type-checking.