### PR TITLE
Add loading spinners, convert code to async

### DIFF
--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -22,6 +22,7 @@ export default {
   isDirectory(src) {
     return fs.statSync(src).isDirectory(src);
   },
+  appendFile: fs.promises.appendFile,
   // currently having to manually copy the sync methods over, there's prob a better way
   rmSync: fs.rmSync,
   readFileSync(file, options) {
@@ -34,12 +35,18 @@ export default {
   writeFileSync: fs.writeFileSync,
   existsSync: fs.existsSync,
   appendFileSync: fs.appendFileSync,
+  readdir(path, options) {
+    return Promise.resolve(this.readdirSync(path, options));
+  },
   readdirSync(path, options) {
     if (dontMock(path)) {
       return actualfs.readdirSync(path, options);
     }
 
     return fs.readdirSync(path, options);
+  },
+  copy(src, dest) {
+    return Promise.resolve(this.copySync(src, dest));
   },
   copySync(src, dest) {
     const sourceFS = dontMock(src) ? actualfs : fs;

--- a/bin/checks/build-with-latest-expo.check.js
+++ b/bin/checks/build-with-latest-expo.check.js
@@ -10,18 +10,24 @@ async function runCheck() {
       stdio: 'inherit',
     });
     execSync('git config --global user.name "CI User"', { stdio: 'inherit' });
-  }
 
-  // build to /dist
-  execSync('yarn build', { stdio: 'inherit' });
+    // build to /dist
+    execSync('yarn build', { stdio: 'inherit' });
+  } else {
+    console.log(
+      "Ensure you've built the app with 'yarn dev' or 'yarn build' first",
+    );
+  }
 
   // clean /builds, cd into it
   fs.rmSync(dir, { recursive: true, force: true });
   fs.mkdirSync(dir, { recursive: true });
   process.chdir(dir);
 
+  const opts = process.env.CI ? '--no-interactive --is-test' : '';
+
   // run CLI
-  execSync('node ../dist/index.js ExpoSample --no-interactive --is-test', {
+  execSync(`node ../dist/index.js ExpoSample --is-test ${opts}`, {
     stdio: 'inherit',
   });
 

--- a/src/commands/__tests__/typescript.test.ts
+++ b/src/commands/__tests__/typescript.test.ts
@@ -48,7 +48,7 @@ test('writes new tsconfig.json, adds dependencies', async () => {
   });
 
   expect(fs.readFileSync('tsconfig.json', 'utf8')).toMatch(
-    '"compilerOptions": {',
+    '"extends": "expo/tsconfig.base"',
   );
 
   expect(print).not.toHaveBeenCalledWith(

--- a/src/commands/eslint.ts
+++ b/src/commands/eslint.ts
@@ -1,28 +1,30 @@
-import chalk from 'chalk';
+import ora from 'ora';
 import addDependency from '../util/addDependency';
 import addPackageJsonScripts from '../util/addPackageJsonScripts';
 import copyTemplateDirectory from '../util/copyTemplateDirectory';
 import isEslintConfigured from '../util/isEslintConfigured';
 import isPackageInstalled from '../util/isPackageInstalled';
-import print from '../util/print';
 
 export default async function addEslint() {
+  const spinner = ora().start('Installing and configuring ESLint');
+
   if (await isEslintConfigured()) {
-    print('eslint config already exists');
-  } else {
-    const hasTypeScript = await isPackageInstalled('typescript');
-
-    await addDependency('eslint @thoughtbot/eslint-config', { dev: true });
-
-    await copyTemplateDirectory({
-      templateDir: 'eslint',
-      variables: { typescript: hasTypeScript },
-    });
-
-    await addPackageJsonScripts({
-      'lint:eslint': 'eslint --max-warnings=0 --ext js,jsx,ts,tsx .',
-    });
-
-    print(chalk.green('🎉 ESLint successfully configured'));
+    spinner.warn('ESLint config already exists, skipping.');
+    return;
   }
+
+  const hasTypeScript = await isPackageInstalled('typescript');
+
+  await addDependency('eslint @thoughtbot/eslint-config', { dev: true });
+
+  await copyTemplateDirectory({
+    templateDir: 'eslint',
+    variables: { typescript: hasTypeScript },
+  });
+
+  await addPackageJsonScripts({
+    'lint:eslint': 'eslint --max-warnings=0 --ext js,jsx,ts,tsx .',
+  });
+
+  spinner.succeed('ESLint successfully configured');
 }

--- a/src/commands/prettier.ts
+++ b/src/commands/prettier.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
+import ora from 'ora';
 import path from 'path';
 import addDependency from '../util/addDependency';
 import addPackageJsonScripts from '../util/addPackageJsonScripts';
@@ -9,13 +9,14 @@ import isPrettierConfigured from '../util/isPrettierConfigured';
 import print from '../util/print';
 
 export default async function addPrettier() {
+  const spinner = ora().start('Installing and configuring Prettier');
   const projectDir = await getProjectDir();
   const eslintJsFile = path.join(projectDir, '.eslintrc.js');
   const eslintJSONFile = path.join(projectDir, '.eslintrc.json');
   let hasEslint = false;
 
   if (await isPrettierConfigured()) {
-    print('prettier config file already exists, exiting');
+    spinner.warn('prettier config file already exists, exiting');
     return;
   }
 
@@ -50,5 +51,5 @@ export default async function addPrettier() {
     );
   }
 
-  print(chalk.green('🎉 Prettier successfully configured'));
+  spinner.succeed('Prettier successfully configured');
 }

--- a/src/commands/scaffold.ts
+++ b/src/commands/scaffold.ts
@@ -1,19 +1,12 @@
-import chalk from 'chalk';
+import ora from 'ora';
 import copyTemplateDirectory from '../util/copyTemplateDirectory';
-import print from '../util/print';
 
 export default async function createScaffold() {
-  print(chalk.bold('👖 Creating directory structure'));
-  print(`
-    src/
-      components/
-      util/
-        hooks/
-      test/
-  `);
+  const spinner = ora().start('Creating directory structure');
 
   await copyTemplateDirectory({
     templateDir: 'scaffold',
   });
-  print('✅ Created directories');
+
+  spinner.succeed('Created directories');
 }

--- a/src/commands/testingLibrary.ts
+++ b/src/commands/testingLibrary.ts
@@ -1,19 +1,18 @@
-import chalk from 'chalk';
-import { execSync } from 'child_process';
+import ora from 'ora';
 import addDependency from '../util/addDependency';
 import addPackageJsonScripts from '../util/addPackageJsonScripts';
 import addToGitignore from '../util/addToGitignore';
 import copyTemplateDirectory from '../util/copyTemplateDirectory';
+import exec from '../util/exec';
 import getPackageManager from '../util/getPackageManager';
 import isExpo from '../util/isExpo';
-import print from '../util/print';
 
 export default async function addTestingLibrary() {
-  print(chalk.bold('👖 Installing Jest and Testing Library'));
+  const spinner = ora().start('Installing Jest and Testing Library');
   const expo = await isExpo();
 
   if (expo) {
-    execSync('npx expo install jest jest-expo');
+    await exec('npx expo install jest jest-expo');
   }
 
   await addDependency(
@@ -42,9 +41,7 @@ export default async function addTestingLibrary() {
 
   await addToGitignore('/.cache');
 
-  print(
-    chalk.green(
-      '\n🎉 Successfully installed and configured Jest and Testing Library\n',
-    ),
+  spinner.succeed(
+    'Successfully installed and configured Jest and Testing Library',
   );
 }

--- a/src/commands/typescript.ts
+++ b/src/commands/typescript.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
+import ora from 'ora';
 import path from 'path';
 import addDependency from '../util/addDependency';
 import addPackageJsonScripts from '../util/addPackageJsonScripts';
@@ -20,6 +21,7 @@ export default async function addTypescript() {
     return;
   }
 
+  const spinner = ora().start('Installing and configuring TypeScript');
   await addDependency('typescript @types/react', { dev: true });
 
   await copyTemplateDirectory({
@@ -29,8 +31,8 @@ export default async function addTypescript() {
     },
   });
 
-  if (fs.existsSync(path.join(projectDir, 'App.js'))) {
-    fs.moveSync(
+  if (await fs.exists(path.join(projectDir, 'App.js'))) {
+    await fs.move(
       path.join(projectDir, 'App.js'),
       path.join(projectDir, 'App.tsx'),
     );
@@ -38,9 +40,5 @@ export default async function addTypescript() {
 
   await addPackageJsonScripts({ 'lint:types': 'tsc' });
 
-  print(
-    chalk.green(
-      '\n🎉 TypeScript successfully configured\nConsider renaming your existing JS files as .ts or .tsx.\n',
-    ),
-  );
+  spinner.succeed('TypeScript successfully configured');
 }

--- a/src/util/addDependency.ts
+++ b/src/util/addDependency.ts
@@ -1,17 +1,15 @@
-import { execSync } from 'child_process';
-import fs from 'fs-extra';
-import * as path from 'path';
-import getProjectDir from './getProjectDir';
+import exec from './exec';
+import getPackageManager from './getPackageManager';
 
 export default async function addDependency(
   deps: string,
   { dev = false } = {},
 ) {
-  const isYarn = await fs.exists(path.join(await getProjectDir(), 'yarn.lock'));
+  const mgr = await getPackageManager();
 
-  if (isYarn) {
-    execSync(`yarn add ${dev ? '--dev' : ''} ${deps}`);
+  if (mgr === 'yarn') {
+    await exec(`yarn add ${dev ? '--dev' : ''} ${deps}`);
   } else {
-    execSync(`npm install ${dev ? '--save-dev' : '--save'} ${deps}`);
+    await exec(`${mgr} install ${dev ? '--save-dev' : '--save'} ${deps}`);
   }
 }

--- a/src/util/addPackageJsonScripts.ts
+++ b/src/util/addPackageJsonScripts.ts
@@ -13,10 +13,6 @@ export default async function addPackageJsonScripts(
   values: Record<string, string>,
   { overwrite = false }: Params = {},
 ) {
-  const names = Object.keys(values);
-  const scriptText = names.length > 1 ? 'scripts' : 'script';
-  print(`Adding package.json ${scriptText}: ${names.join(', ')}`);
-
   const packageJson = await readPackageJson();
 
   Object.entries(values).forEach(([name, command]) => {

--- a/src/util/addToGitignore.ts
+++ b/src/util/addToGitignore.ts
@@ -5,7 +5,7 @@ import getProjectDir from './getProjectDir';
  * lines should be separated by newlines
  */
 export default async function addToGitignore(lines: string) {
-  fs.appendFileSync(
+  return fs.appendFile(
     path.join(await getProjectDir(), '.gitignore'),
     `\n${lines}`,
   );

--- a/src/util/exec.ts
+++ b/src/util/exec.ts
@@ -1,0 +1,5 @@
+import { exec as execCb } from 'child_process';
+import util from 'util';
+
+const exec = util.promisify(execCb);
+export default exec;

--- a/src/util/formatFile.ts
+++ b/src/util/formatFile.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'child_process';
+import exec from './exec';
 
 export default async function formatFile(filePath: string) {
-  execSync(`npx prettier --write '${filePath}'`);
+  return exec(`npx prettier --write '${filePath}'`);
 }

--- a/src/util/getPackageManager.ts
+++ b/src/util/getPackageManager.ts
@@ -6,15 +6,15 @@ export type PackageManager = 'yarn' | 'npm' | 'pnpm';
 export default async function getPackageManager(): Promise<PackageManager> {
   const projectDir = await getProjectDir();
 
-  function fileExists(name: string) {
-    return fs.existsSync(path.join(projectDir, name));
+  async function fileExists(name: string) {
+    return fs.exists(path.join(projectDir, name));
   }
 
-  return fileExists('yarn.lock')
+  return (await fileExists('yarn.lock'))
     ? 'yarn'
-    : fileExists('package-lock.json')
+    : (await fileExists('package-lock.json'))
     ? 'npm'
-    : fileExists('pnpm-lock.yaml')
+    : (await fileExists('pnpm-lock.yaml'))
     ? 'pnpm'
     : throwError('Unable to determine package manager.');
 }

--- a/src/util/writeFile.ts
+++ b/src/util/writeFile.ts
@@ -1,9 +1,7 @@
-import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 import formatFile from './formatFile';
 import getProjectDir from './getProjectDir';
-import print from './print';
 
 type Options = {
   format?: boolean;
@@ -14,8 +12,6 @@ export default async function writeFile(
   contents: string,
   { format = false }: Options = {},
 ) {
-  print(chalk.bold(`🔨 Writing ${filePath}`));
-
   const isAbsolute = filePath.startsWith('/') || filePath.startsWith('\\');
   const fullPath = isAbsolute
     ? filePath

--- a/templates/typescript/tsconfig.json.eta
+++ b/templates/typescript/tsconfig.json.eta
@@ -27,5 +27,8 @@
     "babel.config.js",
     "metro.config.js",
     "jest.config.js"
-  ]
+  ],
+  <% if(it.expo) { %>
+  "extends": "expo/tsconfig.base"
+  <% } %>
 }

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -2,3 +2,15 @@ import { vi } from 'vitest';
 
 vi.mock('child_process');
 vi.mock('fs-extra');
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+  }),
+}));
+
+vi.mock('./src/util/exec', () => ({
+  default: vi.fn().mockResolvedValue(true),
+}));


### PR DESCRIPTION
This cleans up the output of the command. It was very noisy before, and it wasn't obvious which commands the output was related to (esp. when running `create-expo-app`). We might want to still preserve command output and write it to a log file.

Also, we were previously using a mixture of sync and async code. This PR updates the codebase to be fully asynchronous, since the loading spinner cannot animate when using sync code.

https://github.com/thoughtbot/thoughtbelt/assets/1691324/0b5bfec2-1d01-476d-ac0b-7cc15c2e72e5

