### PR TITLE
Install Expo with preferred package manager

### DIFF
--- a/bin/belt.js
+++ b/bin/belt.js
@@ -1,12 +1,34 @@
 #!/usr/bin/env node
+import { execSync } from 'child_process';
+import fs from 'fs-extra';
 
-import { spawn } from 'node:child_process';
-import path from 'node:path';
-import { URL, fileURLToPath } from 'node:url';
+// executes the CLI locally from the `builds` directory
+// this can be useful for troubleshooting
+// eg. node bin/belt.js MyApp, or bun bin/belt.js
+async function run() {
+  const dir = './builds';
 
-const dirname = fileURLToPath(new URL('.', import.meta.url));
-const args = process.argv.slice(2);
+  console.log(
+    "Ensure you've built the app with 'yarn dev' or 'yarn build' first",
+  );
 
-spawn('ts-node', [path.join(dirname, '../src/cli.ts'), ...args], {
-  stdio: 'inherit',
-});
+  // clean /builds, cd into it
+  fs.mkdirSync(dir, { recursive: true });
+  process.chdir(dir);
+
+  // run CLI
+  execSync(
+    `${getNodeRunner()} ../dist/index.js ${process.argv
+      .slice(2)
+      .join(' ')} --is-test`,
+    {
+      stdio: 'inherit',
+    },
+  );
+}
+
+function getNodeRunner() {
+  return Bun && Bun.env ? 'bun' : 'node';
+}
+
+void run();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,10 @@ export default function runCli() {
       '--no-testing',
       'Pass true to skip installing Jest and React Native Testing Library',
     )
+    .option('--bun', 'Use Bun package manager')
+    .option('--yarn', 'Use Yarn package manager')
+    .option('--pnpm', 'Use PNPM package manager')
+    .option('--npm', 'Use NPM package manager')
     .option('--is-test', 'Used only by test suite')
     .option('--no-interactive', 'Pass true to skip all prompts')
     .action(buildAction(import('./commands/createApp')));

--- a/src/types/Global.d.ts
+++ b/src/types/Global.d.ts
@@ -1,0 +1,4 @@
+// this is available as a global only if run in Bun environment
+declare namespace Bun {
+  const Env = {};
+}

--- a/src/util/addDependency.ts
+++ b/src/util/addDependency.ts
@@ -7,8 +7,8 @@ export default async function addDependency(
 ) {
   const mgr = await getPackageManager();
 
-  if (mgr === 'yarn') {
-    await exec(`yarn add ${dev ? '--dev' : ''} ${deps}`);
+  if (['yarn', 'bun'].includes(mgr)) {
+    await exec(`${mgr} add ${dev ? '--dev' : ''} ${deps}`);
   } else {
     await exec(`${mgr} install ${dev ? '--save-dev' : '--save'} ${deps}`);
   }

--- a/src/util/getPackageManager.ts
+++ b/src/util/getPackageManager.ts
@@ -1,8 +1,8 @@
 import fs from 'fs-extra';
 import path from 'path';
 import getProjectDir from './getProjectDir';
+import { PackageManager } from './getUserPackageManager';
 
-export type PackageManager = 'yarn' | 'npm' | 'pnpm';
 export default async function getPackageManager(): Promise<PackageManager> {
   const projectDir = await getProjectDir();
 
@@ -10,12 +10,14 @@ export default async function getPackageManager(): Promise<PackageManager> {
     return fs.exists(path.join(projectDir, name));
   }
 
-  return (await fileExists('yarn.lock'))
+  return (await fileExists('yarn.lock')) || (await fileExists('.yarn'))
     ? 'yarn'
     : (await fileExists('package-lock.json'))
     ? 'npm'
     : (await fileExists('pnpm-lock.yaml'))
     ? 'pnpm'
+    : (await fileExists('bun.lockb'))
+    ? 'bun'
     : throwError('Unable to determine package manager.');
 }
 

--- a/src/util/getUserPackageManager.ts
+++ b/src/util/getUserPackageManager.ts
@@ -1,0 +1,24 @@
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+/**
+ * attempts to detect the runtime / package manager that was used to
+ * run the current process
+ */
+export default function getUserPackageManager(): PackageManager {
+  // This environment variable is set by npm and yarn but pnpm seems less consistent
+  const userAgent = process.env.npm_config_user_agent;
+
+  if (userAgent?.startsWith('yarn')) {
+    return 'yarn';
+  }
+  if (userAgent?.startsWith('pnpm')) {
+    return 'pnpm';
+  }
+  // bun sets Bun.env if running in Bun process. userAgent bit doesn't seem to work
+  if (userAgent?.startsWith('bun') || typeof Bun !== 'undefined') {
+    return 'bun';
+  }
+
+  // If no user agent is set, assume npm
+  return 'npm';
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "sourceMap": true,
     "outDir": "./build",
     "skipLibCheck": true,
-    "types": ["node"]
+    "types": ["node"],
+    "typeRoots": ["./src/types", "./node_modules/@types"]
   },
   "ts-node": {
     "esm": true,


### PR DESCRIPTION
**Motivation:** Expo [supports starting a new app](https://github.com/expo/expo/blob/main/packages/create-expo/README.md) with npm, pnpm, yarn, and bun. Our CLI should respect those options as well.

**Additional motivation:** `bun` is around 5-10x faster (I haven't actually measured but it's quite significant) than `npm` for the initial app creation. The feedback cycle when developing this library is a lot faster if we can test the CLI using `bun`.

## Details

Detects the package manager that was used to start thoughtbelt. So, if for example, we created a new app by running `bunx thoughtbelt MyApp`, thoughtbelt now detects that it's running in a Bun environment and executes `bunx create-expo`. Since the Expo CLI has similar logic, it creates the new app using Bun (i.e. runs `bun install`, which creates a bun lockfile). The same logic also applies to running `yarn create expo`, `npx create-expo`, and `pnpm create expo`.

Additionally, this PR also adds flags to specify the package manager to use for the new app, so we can for example run `npx thoughtbelt@latest MyApp --bun`, and it will create the Expo app with Bun. I think this will be less used, and we might even want to remove prior to v1.