### PR TITLE
Fix async-storage command

### DIFF
--- a/src/commands/createApp.ts
+++ b/src/commands/createApp.ts
@@ -48,15 +48,14 @@ export async function createApp(name: string | undefined, options: Options) {
     await exec('git init');
     await commit('Initial commit');
   }
-  spinner.start('Adding dependencies');
+
   // add dependencies that every project will use
-  await addDependency(
-    [
-      'react-native-keyboard-aware-scrollview',
-      'react-native-safe-area-context',
-      '@react-native-async-storage/async-storage',
-    ].join(' '),
+  spinner.start('Adding dependencies');
+  await exec(
+    'npx expo install @react-native-async-storage/async-storage react-native-safe-area-context',
   );
+  await addDependency('react-native-keyboard-aware-scrollview');
+  await addDependency('thoughtbelt', { dev: true });
   await commit('Add dependencies');
   spinner.succeed('Added dependencies');
 


### PR DESCRIPTION
This PR installs `AsyncStorage` and `react-native-safe-area-context` with `npx expo install` instead of a regular `npm install`. The Expo docs recommend using `npx expo install` for these packages, which ensures that the correct versions are added that have been tested with the current Expo version. We seeing a warning that we were using an incompatible version of AsyncStorage.

Additionally, this PR adds `thoughtbelt` as a dev dependency in the new project so users can continue to use thoughtbelt with eg. `yarn belt`.