### PR TITLE
Don't pass @latest when creating Expo app with yarn

### DIFF
--- a/src/commands/__tests__/createApp.test.ts
+++ b/src/commands/__tests__/createApp.test.ts
@@ -1,6 +1,7 @@
 import { confirm } from '@inquirer/prompts';
 import { fs, vol } from 'memfs';
 import { Mock, afterEach, expect, test, vi } from 'vitest';
+import exec from '../../util/exec';
 import print from '../../util/print';
 import { createApp } from '../createApp';
 
@@ -38,4 +39,23 @@ test('creates app', async () => {
   );
 
   expect(homeScreen).toMatch('expo-status-bar');
+  expect(exec).toHaveBeenCalledWith('yarn create expo MyApp');
+});
+
+test('creates Expo app with npx if npm option passed', async () => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+  vi.spyOn(process, 'chdir').mockImplementation(() => {
+    const json = {
+      'package.json': JSON.stringify({
+        scripts: {},
+        dependencies: {},
+        devDependencies: {},
+      }),
+      'package-lock.json': '',
+    };
+    vol.fromJSON(json, './');
+  });
+  await createApp('MyApp', { testing: true, npm: true });
+
+  expect(exec).toHaveBeenCalledWith('npx --yes create-expo@latest MyApp');
 });

--- a/src/commands/createApp.ts
+++ b/src/commands/createApp.ts
@@ -172,11 +172,11 @@ async function createExpoApp(appName: string, options: Options) {
     mgr === 'yarn'
       ? 'yarn create expo'
       : mgr === 'pnpm'
-      ? 'pnpm create expo'
+      ? 'pnpm create expo@latest'
       : mgr === 'bun'
-      ? 'bunx create-expo'
-      : 'npx --yes create-expo';
+      ? 'bunx create-expo@latest'
+      : 'npx --yes create-expo@latest';
 
-  const fullCommand = `${command}@latest ${appName}`;
+  const fullCommand = `${command} ${appName}`;
   await exec(fullCommand);
 }


### PR DESCRIPTION
When starting a new thoughtbelt project with `npx thoughtbelt MyApp --yarn`, thoughtbelt was attempting to create the Expo app with yarn using the `yarn create expo@latest MyApp` command. This was failing, because `yarn create` does not seem to support the `@latest` symbol. This PR updates so we no longer pass `@latest` when creating the Expo app with Yarn.


The error was:

```
...
? Ready to proceed? yes

⠸ Creating new app with create-expo-appnode:internal/errors:867
  const err = new Error(message);
              ^

Error: Command failed: yarn create expo@latest UsaGym
warning package.json: No license field
/bin/sh: /Users/shanson/.yarn/bin/create-expo@latest: No such file or directory
error Command failed.
Exit code: 127
Command: /Users/shanson/.yarn/bin/create-expo@latest
Arguments: UsaGym
Directory: /Users/shanson/dev/thoughtbelt-playground
```

