### PR TITLE
Remove babel-plugin-module-resolve, not needed for Expo 50

### DIFF
--- a/templates/scaffold/babel.config.js
+++ b/templates/scaffold/babel.config.js
@@ -3,17 +3,5 @@ module.exports = function (api) {
 
   return {
     presets: ['babel-preset-expo'],
-    plugins: [
-      [
-        'module-resolver',
-        {
-          alias: {
-            // This needs to be mirrored in tsconfig.json
-            src: './src',
-            assets: './assets',
-          },
-        },
-      ],
-    ],
   };
 };


### PR DESCRIPTION
Our test suite began (rightly) failing when it tests that thoughtbelt can generate an app using the latest Expo. Expo 50 removed babel-plugin-module-resolver ([issue thread](https://github.com/expo/expo/issues/25923)) and now supports type aliases out of the box without it. thoughtbelt was specifying this plugin in `babel.config.js` for type aliases but was not installing it in the `package.json` for new apps. This PR removes the config for this plugin in `babel.config.js`.

If tests pass, I'm going to go ahead and merge, since the build is currently broken.