### PR TITLE
Change TouchableOpacity to Pressable in template

### DIFF
--- a/templates/boilerplate/src/components/buttons/PrimaryButton.tsx
+++ b/templates/boilerplate/src/components/buttons/PrimaryButton.tsx
@@ -1,19 +1,15 @@
-import {
-  StyleSheet,
-  TouchableOpacity,
-  TouchableOpacityProps,
-} from 'react-native';
+import { StyleSheet, Pressable, PressableProps, ViewStyle } from 'react-native';
 
-type ButtonProps = TouchableOpacityProps;
+type ButtonProps = PressableProps;
 
-export default function PrimaryButton({ style, ...props }: ButtonProps) {
-  return (
-    <TouchableOpacity
-      activeOpacity={0.6}
-      style={[styles.button, style]}
-      {...props}
-    />
-  );
+export default function PrimaryButton({
+  style,
+  ...props
+}: {
+  style: ViewStyle | undefined;
+  props: ButtonProps;
+}) {
+  return <Pressable style={[styles.button, style]} {...props} />;
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
[According to react-native doc](https://reactnative.dev/docs/touchableopacity) the future-proof component to use for buttons is `Pressable`.

This PR changes the button in the template from a TouchableOpacity component to a Pressable one. 