### PR TITLE
Schedule CI workflow to run every night

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: yarn --frozen-lockfile
+        run: yarn install --frozen-lockfile
       - name: Run ESLint, Prettier, tsc
         run: yarn lint
       - name: Run tests

--- a/.github/workflows/scheduled_expo_build.yml
+++ b/.github/workflows/scheduled_expo_build.yml
@@ -13,9 +13,9 @@ jobs:
         node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/scheduled_expo_build.yml
+++ b/.github/workflows/scheduled_expo_build.yml
@@ -1,0 +1,24 @@
+name: Scheduled Expo Build
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Build with latest Expo
+        run: node bin/checks/build-with-latest-expo.check.js


### PR DESCRIPTION
In a GitHub action we can add the [schedule](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) event to run a workflow at a specific time.
In this case we will run the workflow every day at midnight UTC.

The notifications about the workflow will be sent to the user who set it up, in this case myself. More information below. 
> Notifications for scheduled workflows are sent to the user who initially created the workflow. If a different user updates the cron syntax in the workflow file, subsequent notifications will be sent to that user instead. If a scheduled workflow is disabled and then re-enabled, notifications will be sent to the user who re-enabled the workflow rather than the user who last modified the cron syntax.

[Information about notifications.](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs)