### PR TITLE
Fix version mismatch with react-test-renderer

### DIFF
--- a/templates/boilerplate/package.json
+++ b/templates/boilerplate/package.json
@@ -18,12 +18,12 @@
     "test:all": "npm run lint && npm run test:cov"
   },
   "dependencies": {
-    "@expo/vector-icons": "^13.0.0",
+    "@expo/vector-icons": "^14.0.0",
     "@react-native-async-storage/async-storage": "1.21.0",
     "@react-navigation/bottom-tabs": "^6.5.20",
     "@react-navigation/native": "^6.1.10",
     "@react-navigation/native-stack": "^6.9.18",
-    "expo": "^50.0.14",
+    "expo": "^50.0.17",
     "expo-status-bar": "~1.11.1",
     "jest": "^29.3.1",
     "jest-expo": "~50.0.2",
@@ -45,6 +45,7 @@
     "eslint": "^8.56.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",
+    "react-test-renderer": "18.2.0",
     "typescript": "^5.3.3"
   },
   "private": true


### PR DESCRIPTION
Belt is currently failing due to a dependency mismatch. The issue is that `@testing-library/jest-native@5.4.3` installs `react-test-renderer` with no pinned version. The latest `react-test-renderer`, 18.3.0, has a peer dependency on React 18.3.0. Our app uses React 18.2.0, which is the compatible version with the latest Expo, so changing that was not an option. To resolve, I made `react-test-renderer` an explicit dependency and locked it to our React version, 18.2.0. Now Belt is working again.

I also followed the guide in [CONTRIBUTING.md](https://github.com/thoughtbot/belt/blob/main/CONTRIBUTING.md#updating-belt-dependencies) and updated our Expo dependencies (patch version of Expo, minor version of @expo/vector-icons) while I was in there.

Here is the output when running against beta build 0.5.0 (current `main`):

```
❯ npx create-belt-app@0.5.0 App0_5_0


        👖 Belt 👖

Perform project setup and redundant tasks
    without your pants falling down!


Let’s get started!

We will now create a new app in ./App0502 for you with all of the following goodies:

  - Expo
  - TypeScript
  - Prettier
  - ESLint
  - Jest, React Native Testing Library
  - React Navigation
  - Intuitive directory structure

? Ready to proceed? yes

✔ Created new Belt app with Expo
⠴ Installing dependenciesnode:internal/errors:984
  const err = new Error(message);
              ^

Error: Command failed: npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: app-0502@1.0.0
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   react@"18.2.0" from the root project
npm ERR!   peer react@">=16.0.0" from @testing-library/jest-native@5.4.3
npm ERR!   node_modules/@testing-library/jest-native
npm ERR!     dev @testing-library/jest-native@"^5.4.3" from the root project
npm ERR!   1 more (react-native)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^18.3.0" from react-test-renderer@18.3.0
npm ERR! node_modules/react-test-renderer
npm ERR!   peer react-test-renderer@">=16.0.0" from @testing-library/jest-native@5.4.3
npm ERR!   node_modules/@testing-library/jest-native
npm ERR!     dev @testing-library/jest-native@"^5.4.3" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR!
npm ERR! For a full report see:
npm ERR! /Users/shanson/.npm/_logs/2024-04-26T14_22_56_442Z-eresolve-report.txt

npm ERR! A complete log of this run can be found in: /Users/shanson/.npm/_logs/2024-04-26T14_22_56_442Z-debug-0.log
```