### PR TITLE
Pin '@types/react' to 18.2

### DIFF
--- a/templates/boilerplate/package.json
+++ b/templates/boilerplate/package.json
@@ -39,7 +39,7 @@
     "@testing-library/react-native": "^12.4.5",
     "@thoughtbot/eslint-config": "^1.0.2",
     "@types/jest": "^29.5.12",
-    "@types/react": "^18.2.73",
+    "@types/react": "~18.2.73",
     "babel-jest": "^29.7.0",
     "create-belt-app": "^0.4.0",
     "eslint": "^8.56.0",


### PR DESCRIPTION
I was seeing this warning when running `npm run ios` on a newly installed app:

> The following packages should be updated for best compatibility with the installed expo version:
>    @types/react@18.3.0 - expected version: ~18.2.45
> Your project may not work correctly until you install the correct versions of the packages.

I noticed that we were only pinning the major version of `@types/react`, so I updated to also pin the minor version to match the React minor version 18.2.x. Now, I do not see that warning when starting a new Belt app.