### PR TITLE
Upgrade to Expo SDK 51.0.0

### DIFF
--- a/templates/boilerplate/package.json
+++ b/templates/boilerplate/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
-    "@react-native-async-storage/async-storage": "1.21.0",
+    "@react-native-async-storage/async-storage": "1.23.1",
     "@react-navigation/bottom-tabs": "^6.5.20",
     "@react-navigation/native": "^6.1.10",
     "@react-navigation/native-stack": "^6.9.18",
@@ -29,9 +29,9 @@
     "expo-status-bar": "~1.12.1",
     "msw": "^2.2.14",
     "react": "18.2.0",
-    "react-native": "0.74.3",
+    "react-native": "0.74.5",
     "react-native-keyboard-aware-scrollview": "^2.1.0",
-    "react-native-safe-area-context": "4.10.1",
+    "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1"
   },
   "devDependencies": {
@@ -50,7 +50,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",
     "react-test-renderer": "18.2.0",
-    "typescript": "^5.3.3"
+    "typescript": "~5.3.3"
   },
   "private": true
 }

--- a/templates/boilerplate/package.json
+++ b/templates/boilerplate/package.json
@@ -18,23 +18,21 @@
     "test:all": "npm run lint && npm run test:cov"
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.0.0",
+    "@expo/vector-icons": "^14.0.2",
     "@react-native-async-storage/async-storage": "1.21.0",
     "@react-navigation/bottom-tabs": "^6.5.20",
     "@react-navigation/native": "^6.1.10",
     "@react-navigation/native-stack": "^6.9.18",
     "@tanstack/react-query": "^5.32.1",
     "axios": "^1.6.8",
-    "expo": "^50.0.17",
-    "expo-status-bar": "~1.11.1",
-    "jest": "^29.3.1",
-    "jest-expo": "~50.0.2",
+    "expo": "~51.0.18",
+    "expo-status-bar": "~1.12.1",
     "msw": "^2.2.14",
     "react": "18.2.0",
-    "react-native": "0.73.6",
+    "react-native": "0.74.3",
     "react-native-keyboard-aware-scrollview": "^2.1.0",
-    "react-native-safe-area-context": "4.8.2",
-    "react-native-screens": "~3.29.0"
+    "react-native-safe-area-context": "4.10.1",
+    "react-native-screens": "3.31.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -47,6 +45,8 @@
     "babel-jest": "^29.7.0",
     "create-belt-app": "^0.4.0",
     "eslint": "^8.56.0",
+    "jest": "^29.3.1",
+    "jest-expo": "~51.0.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",
     "react-test-renderer": "18.2.0",


### PR DESCRIPTION
## Summary

This PR upgrades belt from Expo SDK 50 to SDK 51, bringing in the latest features, improvements, and bug fixes from Expo. Additionally, the `jest` related packages are now listed under `devDependencies` instead of `dependencies`.

## Testing

Created a new Expo app using the CLI and verified that the App build and all tests run successfully using the `yarn test:all` command.

## Unrelated bug

<img width="200" src="https://github.com/thoughtbot/belt/assets/28998674/50b9a6bf-a494-417e-acb1-1fccb898239b">

However we have an unrelated bug due to the [Coffee API](https://api.sampleapis.com/coffee) being down but this should not prevent this upgrade PR from being merged.