### PR TITLE
Add SECURITY.md to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+SECURITY.md


### PR DESCRIPTION
SECURITY.md is auto-generated by a thoughtbot template and results in a Prettier error, which is currently breaking CI. Turning prettier off for this file, since we don't control it.