### PR TITLE
Fix codeowners typo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,5 +12,4 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Global rule:
-*           @stevehanson
-*           @codeofdiego
+* @stevehanson @codeofdiego


### PR DESCRIPTION
This was resulting in only Diego being a codeowner. [Codeowners documentation reference](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

<img width="310" alt="image" src="https://github.com/user-attachments/assets/4b428603-940a-4caf-9d45-27abddf5910b">

<img width="932" alt="image" src="https://github.com/user-attachments/assets/aa4b9b03-b4b2-4c53-ab6b-74732f2d24a3">
