### PR TITLE
Change projects API to thoughtbot-hosted app

### DIFF
--- a/templates/boilerplate/src/__tests__/App.integration.test.tsx
+++ b/templates/boilerplate/src/__tests__/App.integration.test.tsx
@@ -38,7 +38,7 @@ test('renders app, can navigate between screens', async () => {
 // Recommended to place these mocks in a central location like `src/test/mocks`
 function mockGitHubProjects() {
   return mock.get<GithubProjectsResponse, null>(
-    'https://github-projects-api.vercel.app/api/projects',
+    'https://thoughtbot-projects-api-68b03dc59059.herokuapp.com/api/projects',
     {
       response: {
         projects: [

--- a/templates/boilerplate/src/util/api/api.ts
+++ b/templates/boilerplate/src/util/api/api.ts
@@ -27,7 +27,7 @@ const api = {
   // TODO: sample, remove
   githubRepos: () =>
     makeRequest<GithubProjectsResponse>({
-      url: 'https://github-projects-api.vercel.app/api/projects',
+      url: 'https://thoughtbot-projects-api-68b03dc59059.herokuapp.com/api/projects',
     }),
 };
 


### PR DESCRIPTION
Previously, this was pointing at an app hosted on my Vercel account. 

Relevant links for the API:

* [private GitHub repo](https://github.com/thoughtbot/github-projects-api)
* [private Heroku app](https://dashboard.heroku.com/apps/thoughtbot-projects-api)
* [API endpoint](https://thoughtbot-projects-api-68b03dc59059.herokuapp.com/api/projects)