### PR TITLE
Open summit - add version support

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,24 @@
+import { test, vi, expect, beforeEach } from 'vitest';
+import packageJson from '../../package.json';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+test('outputs version with --version flag', async () => {
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+  const exitSpy = vi
+    .spyOn(process, 'exit')
+    .mockImplementation(() => undefined as never);
+
+  process.argv = ['node', 'belt', '--version'];
+  const { default: runCli } = await import('../cli');
+  runCli();
+
+  expect(writeSpy).toHaveBeenCalledWith(
+    expect.stringContaining(packageJson.version),
+  );
+
+  writeSpy.mockRestore();
+  exitSpy.mockRestore();
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,9 @@
 import { program } from 'commander';
 import buildAction from './util/buildAction';
 import printWelcome from './util/print/printWelcome';
+import packageJson from '../package.json';
+
+const typedPackageJson = packageJson;
 
 export default function runCli() {
   program
@@ -61,6 +64,10 @@ export default function runCli() {
       'Pass true to skip all prompts and use default values',
     )
     .action(buildAction(import('./commands/notifications')));
+
+  program.version(
+    `The current version of Belt is: ${typedPackageJson.version}`,
+  );
 
   printWelcome();
   program.parse();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,14 +3,13 @@ import buildAction from './util/buildAction';
 import printWelcome from './util/print/printWelcome';
 import packageJson from '../package.json';
 
-const typedPackageJson = packageJson;
-
 export default function runCli() {
   program
     .name('Belt')
     .description(
       'Perform React Native and Expo setup and redundant tasks without your pants falling down!',
     )
+    .version(packageJson.version)
     .showHelpAfterError();
 
   program
@@ -65,10 +64,6 @@ export default function runCli() {
     )
     .action(buildAction(import('./commands/notifications')));
 
-  program.version(
-    `The current version of Belt is: ${typedPackageJson.version}`,
-  );
-
-  printWelcome();
   program.parse();
+  printWelcome();
 }

--- a/src/util/print/__tests__/printWelcome.test.ts
+++ b/src/util/print/__tests__/printWelcome.test.ts
@@ -1,8 +1,30 @@
-import { test, vi } from 'vitest';
+import { test, vi, describe, expect, beforeEach } from 'vitest';
+import chalk from 'chalk';
 import printWelcome from '../printWelcome';
 
-vi.mock('../../print', () => ({ default: vi.fn() }));
+const consoleSpy = vi.spyOn(console, 'log');
 
-test('doesnt error', () => {
-  printWelcome();
+describe('printWelcome', () => {
+  beforeEach(() => {
+    consoleSpy.mockClear();
+  });
+
+  test('prints introduction message', () => {
+    process.argv = ['node', 'script.js', 'create'];
+    printWelcome();
+    expect(console.log).toHaveBeenCalledWith(chalk.bold('\n\n\t👖 Belt 👖\n'));
+  });
+
+  describe('does not print introduction message for version', () => {
+    test('works for --version', () => {
+      process.argv = ['node', 'script.js', '--version'];
+      printWelcome();
+      expect(consoleSpy.mock.calls.length).toBe(0);
+    });
+    test('works for -V', () => {
+      process.argv = ['node', 'script.js', '-V'];
+      printWelcome();
+      expect(consoleSpy.mock.calls.length).toBe(0);
+    });
+  });
 });

--- a/src/util/print/__tests__/printWelcome.test.ts
+++ b/src/util/print/__tests__/printWelcome.test.ts
@@ -1,30 +1,15 @@
-import { test, vi, describe, expect, beforeEach } from 'vitest';
+import { test, vi, expect } from 'vitest';
 import chalk from 'chalk';
 import printWelcome from '../printWelcome';
+import print from '../../print';
 
-const consoleSpy = vi.spyOn(console, 'log');
+vi.mock('../../print', () => ({ default: vi.fn() }));
 
-describe('printWelcome', () => {
-  beforeEach(() => {
-    consoleSpy.mockClear();
-  });
-
-  test('prints introduction message', () => {
-    process.argv = ['node', 'script.js', 'create'];
-    printWelcome();
-    expect(console.log).toHaveBeenCalledWith(chalk.bold('\n\n\t👖 Belt 👖\n'));
-  });
-
-  describe('does not print introduction message for version', () => {
-    test('works for --version', () => {
-      process.argv = ['node', 'script.js', '--version'];
-      printWelcome();
-      expect(consoleSpy.mock.calls.length).toBe(0);
-    });
-    test('works for -V', () => {
-      process.argv = ['node', 'script.js', '-V'];
-      printWelcome();
-      expect(consoleSpy.mock.calls.length).toBe(0);
-    });
-  });
+test('prints welcome message', () => {
+  printWelcome();
+  expect(print).toHaveBeenNthCalledWith(1, chalk.bold('\n\n\t👖 Belt 👖\n'));
+  expect(print).toHaveBeenNthCalledWith(
+    2,
+    'Perform project setup and redundant tasks\n    without your pants falling down!\n\n',
+  );
 });

--- a/src/util/print/printWelcome.ts
+++ b/src/util/print/printWelcome.ts
@@ -2,6 +2,11 @@ import chalk from 'chalk';
 import print from '../print';
 
 export default function printWelcome() {
+  const showVersionCommand =
+    process.argv.includes('--version') || process.argv.includes('-V');
+  if (showVersionCommand) {
+    return;
+  }
   print(chalk.bold('\n\n\t👖 Belt 👖\n'));
   print(
     'Perform project setup and redundant tasks\n    without your pants falling down!\n\n',

--- a/src/util/print/printWelcome.ts
+++ b/src/util/print/printWelcome.ts
@@ -2,11 +2,6 @@ import chalk from 'chalk';
 import print from '../print';
 
 export default function printWelcome() {
-  const showVersionCommand =
-    process.argv.includes('--version') || process.argv.includes('-V');
-  if (showVersionCommand) {
-    return;
-  }
   print(chalk.bold('\n\n\t👖 Belt 👖\n'));
   print(
     'Perform project setup and redundant tasks\n    without your pants falling down!\n\n',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "outDir": "./build",
     "skipLibCheck": true,
     "types": ["node"],
-    "typeRoots": ["./src/types", "./node_modules/@types"]
+    "typeRoots": ["./src/types", "./node_modules/@types"],
+    "resolveJsonModule": true
   },
   "ts-node": {
     "esm": true,


### PR DESCRIPTION
This PR supports a `version` option to the Belt CLI. Users should be able to use:

```
npx create-belt-app --version
npx create-belt-app -V
```

which would output the version of the Belt CLI being used. 

## Changes
- `src/cli.ts` — chains `.version(packageJson.version)` into the root program setup alongside `.name()` and `.description()`. 
- Moves `printWelcome()` to after `program.parse()` so Commander's natural process exit on `--version` suppresses the welcome banner without any extra logic.
- `tsconfig.json` — adds `resolveJsonModule: true` to support the `package.json` import.