### PR TITLE
🐞 Fix Nightly build problems due to test suite errors

### DIFF
--- a/templates/boilerplate/jest.config.js
+++ b/templates/boilerplate/jest.config.js
@@ -13,4 +13,7 @@ module.exports = {
     '@testing-library/jest-native/extend-expect',
     './jest.setup.js',
   ],
+  testEnvironmentOptions: {
+    customExportConditions: [''],
+  },
 };

--- a/templates/testingLibrary/jest.config.js
+++ b/templates/testingLibrary/jest.config.js
@@ -13,4 +13,7 @@ module.exports = {
     '@testing-library/jest-native/extend-expect',
     './jest.setup.js',
   ],
+  testEnvironmentOptions: {
+    customExportConditions: [''],
+  },
 };


### PR DESCRIPTION
Based on [msw](https://mswjs.io/docs/migrations/1.x-to-2.x/#cannot-find-module-mswnode-jsdom) setup guide, we need to add the test environment options to the Jest config files.

This PR hopefully fixes https://github.com/thoughtbot/belt/issues/70

Co-authored-by: @laicuRoot