### PR TITLE
Add prompt for what package manager Belt should use

### DIFF
--- a/src/commands/createApp.ts
+++ b/src/commands/createApp.ts
@@ -55,9 +55,9 @@ export async function createApp(
     spinner.succeed('Created new Belt app with Expo');
 
     process.chdir(`./${appName}`);
+    const packageManager = await getPackageManager(options);
 
     spinner.start('Installing dependencies');
-    const packageManager = getPackageManager(options);
     await exec(`${packageManager} install`);
     await exec('git init');
     await commit('Initial commit');

--- a/src/util/getUserPackageManager.ts
+++ b/src/util/getUserPackageManager.ts
@@ -1,24 +1,18 @@
-export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+import { select } from '@inquirer/prompts';
+
+const PACKAGE_MANAGER_CHOICES = ['npm', 'pnpm', 'yarn', 'bun'] as const;
+
+export type PackageManager = (typeof PACKAGE_MANAGER_CHOICES)[number];
 
 /**
- * attempts to detect the runtime / package manager that was used to
- * run the current process
+ * requests the user to select their preferred package manager from the
+ * provided list
  */
-export default function getUserPackageManager(): PackageManager {
-  // This environment variable is set by npm and yarn but pnpm seems less consistent
-  const userAgent = process.env.npm_config_user_agent;
-
-  if (userAgent?.startsWith('yarn')) {
-    return 'yarn';
-  }
-  if (userAgent?.startsWith('pnpm')) {
-    return 'pnpm';
-  }
-  // bun sets Bun.env if running in Bun process. userAgent bit doesn't seem to work
-  if (userAgent?.startsWith('bun') || typeof Bun !== 'undefined') {
-    return 'bun';
-  }
-
-  // If no user agent is set, assume npm
-  return 'npm';
+export default async function getUserPackageManager(): Promise<PackageManager> {
+  return select({
+    message: 'What package manager would you like Belt to use?',
+    choices: PACKAGE_MANAGER_CHOICES.map((packageManager) => ({
+      value: packageManager,
+    })),
+  });
 }


### PR DESCRIPTION
This PR aims to resolve the issue raised [here](https://github.com/thoughtbot/belt/issues/66). This enhancement ensures that whenever users run the Belt CLI tool like this: ```npx create-belt-app --yarn```, it runs normally as it would. However, if they don't add the package manager tool, then they're presented with a list of choices to pick from. The output should look same as in the attached screenshot.

<img width="418" height="83" alt="Screenshot 2025-12-16 at 10 48 40 AM" src="https://github.com/user-attachments/assets/22e9a895-042f-4f08-9403-87894ff7f4d8" />

