### PR TITLE
Modify to use GitHub API in the generated app

### DIFF
--- a/templates/boilerplate/src/__tests__/App.integration.test.tsx
+++ b/templates/boilerplate/src/__tests__/App.integration.test.tsx
@@ -2,7 +2,7 @@ import { screen, userEvent } from '@testing-library/react-native';
 
 import mock from 'src/test/mock';
 import { renderApplication } from 'src/test/render';
-import { GithubProjectsResponse } from 'src/util/api/api';
+import type { GithubRepo } from 'src/util/api/api';
 
 // Testing philosophy:
 // - Tests that render the entire application with `renderApplication` go in the
@@ -37,22 +37,20 @@ test('renders app, can navigate between screens', async () => {
 // Pass this mock to `render` or `renderApplication` to register it with MSW.
 // Recommended to place these mocks in a central location like `src/test/mocks`
 function mockGitHubProjects() {
-  return mock.get<GithubProjectsResponse, null>(
-    'https://thoughtbot-projects-api-68b03dc59059.herokuapp.com/api/projects',
+  return mock.get<GithubRepo[], null>(
+    'https://api.github.com/orgs/thoughtbot/repos',
     {
-      response: {
-        projects: [
-          {
-            id: 635980144,
-            name: 'belt',
-            description:
-              'Belt is a CLI for starting a new React Native Expo app and will even keep your pants secure as you continue development.',
-            url: 'https://github.com/thoughtbot/belt',
-            stars: 8,
-            forks: 0,
-          },
-        ],
-      },
+      response: [
+        {
+          id: 635980144,
+          name: 'belt',
+          description:
+            'Belt is a CLI for starting a new React Native Expo app and will even keep your pants secure as you continue development.',
+          html_url: 'https://github.com/thoughtbot/belt',
+          stargazers_count: 8,
+          forks_count: 0,
+        },
+      ],
     },
   );
 }

--- a/templates/boilerplate/src/util/api/api.ts
+++ b/templates/boilerplate/src/util/api/api.ts
@@ -23,17 +23,39 @@ async function makeRequest<TData>(options: Params): Promise<TData> {
   return response.data;
 }
 
+function mapRepoToProject(repo: GithubRepo): GithubProject {
+  return {
+    id: repo.id,
+    name: repo.name,
+    description: repo.description,
+    url: repo.html_url,
+    stars: repo.stargazers_count,
+    forks: repo.forks_count,
+  };
+}
+
 const api = {
-  // TODO: sample, remove
-  githubRepos: () =>
-    makeRequest<GithubProjectsResponse>({
-      url: 'https://thoughtbot-projects-api-68b03dc59059.herokuapp.com/api/projects',
-    }),
+  // Fetch thoughtbot's public repositories from GitHub API
+  githubRepos: (): Promise<GithubProjectsResponse> =>
+    makeRequest<GithubRepo[]>({
+      url: 'https://api.github.com/orgs/thoughtbot/repos',
+    }).then((repos) => ({
+      projects: repos.map(mapRepoToProject),
+    })),
 };
 
 // TODO: sample data, remove
 export type GithubProjectsResponse = {
   projects: GithubProject[];
+};
+
+type GithubRepo = {
+  id: number;
+  name: string;
+  description: string | null;
+  html_url: string;
+  stargazers_count: number;
+  forks_count: number;
 };
 
 export type GithubProject = {

--- a/templates/boilerplate/src/util/api/api.ts
+++ b/templates/boilerplate/src/util/api/api.ts
@@ -49,7 +49,7 @@ export type GithubProjectsResponse = {
   projects: GithubProject[];
 };
 
-type GithubRepo = {
+export type GithubRepo = {
   id: number;
   name: string;
   description: string | null;


### PR DESCRIPTION
This PR updates the boilerplate App to fetch GitHub repository data from the GitHub API instead of using thoughtbot internal API (https://thoughtbot-projects-api-68b03dc59059.herokuapp.com/api/projects).

Changes:

- Replaced the API endpoint with the official GitHub API (https://api.github.com/orgs/thoughtbot/repos)
- Added proper response transformation to map GitHub API fields to the expected project format

This provides more reliable GitHub repository information in the generated Belt apps.