### PR TITLE
Fix Jest config for MSW + axios compatibility

### DIFF
--- a/templates/boilerplate/jest.config.js
+++ b/templates/boilerplate/jest.config.js
@@ -3,8 +3,11 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
   coveragePathIgnorePatterns: ['/node_modules', 'src/test'],
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native-community|@react-native|react-native|@react-navigation)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|until-async)',
+    'node_modules/(?!((jest-)?react-native|@react-native-community|@react-native|react-native|@react-navigation)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|until-async|@open-draft|rettime)',
   ],
+  transform: {
+    '^.+\\.mjs$': 'babel-jest',
+  },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: {
     '.+\\.(png|jpg|ttf|woff|woff2)$': '<rootDir>/src/test/fileMock.js',

--- a/templates/boilerplate/jest.setup.js
+++ b/templates/boilerplate/jest.setup.js
@@ -4,6 +4,8 @@ import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
 import server from 'src/test/server';
 import queryClient from 'src/util/api/queryClient';
 
+global.ReadableStream = require('stream/web').ReadableStream;
+
 beforeEach(() => {
   jest.clearAllMocks();
 });


### PR DESCRIPTION
## Description

Jest tests were failing with the error below on freshly created Expo app using the CLI.

```
({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){import { LensList } from "./lens-list.mjs";
                                                                                      ^^^^^^

    SyntaxError: Cannot use import statement outside a module

    > 1 | import { setupServer } from 'msw/node';
        | ^
      2 |
      3 | /**
      4 |  * MSW server for mocking network requests

      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1505:14)
      at Object.<anonymous> (node_modules/msw/src/core/experimental/define-network.ts:2:47)
      at Object.<anonymous> (node_modules/msw/src/node/setup-server.ts:9:8)
      at Object.require (src/test/server.ts:1:1)
      at Object.require (jest.setup.js:4:1)
```

Jest fixes were made to the Expo app built from the boilerplate Belt template and ported to the CLI as well so that tests for new apps don't break.

## Related links
- https://mswjs.io/docs/integrations/react-native/#prerequisites
- https://github.com/mswjs/msw/issues/2698
- https://github.com/mswjs/msw/issues/170