### PR TITLE
Add environment variables using Belt CLI

### DIFF
--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -14,6 +14,9 @@ export default {
     DONT_MOCK_PATTERNS = [];
   },
   ...memfs.promises,
+  pathExists(path) {
+    return this.exists(path);
+  },
   exists(path) {
     if (dontMock(path)) {
       return fse.exists(path);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,7 +69,7 @@ export default function runCli() {
   add
     .command('env')
     .description(
-      'Set up environment variable management with expo-constants and dotenv',
+      'Set up environment variable management using the built-in EXPO_PUBLIC_ mechanism',
     )
     .option(
       '--no-interactive',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,9 +47,11 @@ export default function runCli() {
     .description('Install and configure Jest and Testing Library')
     .action(buildAction(import('./commands/testingLibrary')));
 
-  program
+  const add = program
     .command('add')
-    .description('Add a new feature to your project')
+    .description('Add a new feature to your project');
+
+  add
     .command('notifications')
     .description(
       'Install and configure React Native Firebase with Notifications',
@@ -64,6 +66,17 @@ export default function runCli() {
     )
     .action(buildAction(import('./commands/notifications')));
 
-  program.parse();
+  add
+    .command('env')
+    .description(
+      'Set up environment variable management with expo-constants and dotenv',
+    )
+    .option(
+      '--no-interactive',
+      'Pass true to skip all prompts and use default values',
+    )
+    .action(buildAction(import('./commands/env')));
+
   printWelcome();
+  program.parse();
 }

--- a/src/commands/__tests__/env.test.ts
+++ b/src/commands/__tests__/env.test.ts
@@ -1,0 +1,134 @@
+import { confirm } from '@inquirer/prompts';
+import { fs, vol } from 'memfs';
+import { Mock, afterEach, expect, test, vi } from 'vitest';
+import exec from '../../util/exec';
+import { addEnv } from '../env';
+
+vi.mock('../../util/print', () => ({ default: vi.fn() }));
+vi.mock('@inquirer/prompts', () => ({ confirm: vi.fn() }));
+vi.mock('../../util/exec');
+
+const baseFiles = {
+  'package.json': JSON.stringify({
+    scripts: {},
+    dependencies: {},
+    devDependencies: {},
+  }),
+  'yarn.lock': '',
+};
+
+afterEach(() => {
+  vol.reset();
+  vi.clearAllMocks();
+});
+
+test('copies all template files to correct destinations', async () => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+  vol.fromJSON(baseFiles, './');
+
+  await addEnv();
+
+  expect(fs.existsSync('.env.example')).toBe(true);
+  expect(fs.existsSync('.env')).toBe(true);
+  expect(fs.existsSync('.env.test')).toBe(true);
+  expect(fs.existsSync('jest.setup.env.js')).toBe(true);
+  expect(fs.existsSync('src/config/index.ts')).toBe(true);
+});
+
+test('creates .env from .env.example when .env does not exist', async () => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+  vol.fromJSON(baseFiles, './');
+
+  await addEnv();
+
+  const envContent = fs.readFileSync('.env', 'utf8');
+  const envExampleContent = fs.readFileSync('.env.example', 'utf8');
+  expect(envContent).toBe(envExampleContent);
+});
+
+test('does not overwrite .env when it already exists', async () => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+  vol.fromJSON({ ...baseFiles, '.env': 'EXISTING_VAR=value' }, './');
+
+  await addEnv();
+
+  const envContent = fs.readFileSync('.env', 'utf8');
+  expect(envContent).toBe('EXISTING_VAR=value');
+});
+
+test('adds .env to .gitignore', async () => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+  vol.fromJSON({ ...baseFiles, '.gitignore': 'node_modules\n' }, './');
+
+  await addEnv();
+
+  const gitignore = fs.readFileSync('.gitignore', 'utf8');
+  expect(gitignore).toMatch('.env');
+});
+
+test('installs dotenv as a dev dependency', async () => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+  vol.fromJSON(baseFiles, './');
+
+  await addEnv();
+
+  expect(exec).toHaveBeenCalledWith('yarn add --dev dotenv');
+});
+
+test('patches API file when it contains hardcoded URL', async () => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+  vol.fromJSON(
+    {
+      ...baseFiles,
+      'src/util/api/api.ts': `const url = 'https://api.github.com/orgs/thoughtbot/repos';`,
+    },
+    './',
+  );
+
+  await addEnv();
+
+  const apiContent = fs.readFileSync('src/util/api/api.ts', 'utf8');
+  expect(apiContent).toMatch('EXPO_PUBLIC_API_BASE_URL');
+  expect(apiContent).not.toMatch(
+    "'https://api.github.com/orgs/thoughtbot/repos'",
+  );
+});
+
+test('does not error when API file does not exist', async () => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+  vol.fromJSON(baseFiles, './');
+
+  await expect(addEnv()).resolves.toBeUndefined();
+});
+
+test('patches Jest config when it contains setupFilesAfterEnv', async () => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+  vol.fromJSON(
+    {
+      ...baseFiles,
+      'jest.config.js': `module.exports = {\n  setupFilesAfterEnv: [\n    './jest.setup.js'\n  ]\n};`,
+    },
+    './',
+  );
+
+  await addEnv();
+
+  const jestConfig = fs.readFileSync('jest.config.js', 'utf8');
+  expect(jestConfig).toMatch("setupFiles: ['./jest.setup.env.js']");
+  expect(jestConfig).toMatch('setupFilesAfterEnv');
+});
+
+test('does not error when Jest config does not exist', async () => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+  vol.fromJSON(baseFiles, './');
+
+  await expect(addEnv()).resolves.toBeUndefined();
+});
+
+test('skips confirmation prompt in non-interactive mode', async () => {
+  vol.fromJSON(baseFiles, './');
+
+  await addEnv({ interactive: false });
+
+  expect(confirm).not.toHaveBeenCalled();
+});

--- a/src/commands/__tests__/env.test.ts
+++ b/src/commands/__tests__/env.test.ts
@@ -1,6 +1,6 @@
 import { confirm } from '@inquirer/prompts';
 import { fs, vol } from 'memfs';
-import { Mock, afterEach, expect, test, vi } from 'vitest';
+import { Mock, afterEach, beforeEach, expect, test, vi } from 'vitest';
 import exec from '../../util/exec';
 import { addEnv } from '../env';
 
@@ -17,13 +17,16 @@ const baseFiles = {
   'yarn.lock': '',
 };
 
+beforeEach(() => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+});
+
 afterEach(() => {
   vol.reset();
   vi.clearAllMocks();
 });
 
 test('copies all template files to correct destinations', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
   vol.fromJSON(baseFiles, './');
 
   await addEnv();
@@ -36,7 +39,6 @@ test('copies all template files to correct destinations', async () => {
 });
 
 test('creates .env from .env.example when .env does not exist', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
   vol.fromJSON(baseFiles, './');
 
   await addEnv();
@@ -47,7 +49,6 @@ test('creates .env from .env.example when .env does not exist', async () => {
 });
 
 test('does not overwrite .env when it already exists', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
   vol.fromJSON({ ...baseFiles, '.env': 'EXISTING_VAR=value' }, './');
 
   await addEnv();
@@ -57,7 +58,6 @@ test('does not overwrite .env when it already exists', async () => {
 });
 
 test('adds .env to .gitignore', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
   vol.fromJSON({ ...baseFiles, '.gitignore': 'node_modules\n' }, './');
 
   await addEnv();
@@ -67,7 +67,6 @@ test('adds .env to .gitignore', async () => {
 });
 
 test('installs dotenv as a dev dependency', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
   vol.fromJSON(baseFiles, './');
 
   await addEnv();
@@ -76,7 +75,6 @@ test('installs dotenv as a dev dependency', async () => {
 });
 
 test('patches API file when it contains hardcoded URL', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
   vol.fromJSON(
     {
       ...baseFiles,
@@ -95,14 +93,12 @@ test('patches API file when it contains hardcoded URL', async () => {
 });
 
 test('does not error when API file does not exist', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
   vol.fromJSON(baseFiles, './');
 
   await expect(addEnv()).resolves.toBeUndefined();
 });
 
 test('patches Jest config when it contains setupFilesAfterEnv', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
   vol.fromJSON(
     {
       ...baseFiles,
@@ -119,7 +115,6 @@ test('patches Jest config when it contains setupFilesAfterEnv', async () => {
 });
 
 test('does not error when Jest config does not exist', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
   vol.fromJSON(baseFiles, './');
 
   await expect(addEnv()).resolves.toBeUndefined();

--- a/src/commands/__tests__/env.test.ts
+++ b/src/commands/__tests__/env.test.ts
@@ -1,7 +1,6 @@
 import { confirm } from '@inquirer/prompts';
 import { fs, vol } from 'memfs';
 import { Mock, afterEach, beforeEach, expect, test, vi } from 'vitest';
-import exec from '../../util/exec';
 import { addEnv } from '../env';
 
 vi.mock('../../util/print', () => ({ default: vi.fn() }));
@@ -33,9 +32,18 @@ test('copies all template files to correct destinations', async () => {
 
   expect(fs.existsSync('.env.example')).toBe(true);
   expect(fs.existsSync('.env')).toBe(true);
-  expect(fs.existsSync('.env.test')).toBe(true);
   expect(fs.existsSync('jest.setup.env.js')).toBe(true);
   expect(fs.existsSync('src/config/index.ts')).toBe(true);
+});
+
+test('sets test environment variables directly, without dotenv', async () => {
+  vol.fromJSON(baseFiles, './');
+
+  await addEnv();
+
+  const jestSetupEnv = fs.readFileSync('jest.setup.env.js', 'utf8');
+  expect(jestSetupEnv).toMatch('process.env.EXPO_PUBLIC_API_BASE_URL');
+  expect(jestSetupEnv).not.toMatch('dotenv');
 });
 
 test('creates .env from .env.example when .env does not exist', async () => {
@@ -64,14 +72,6 @@ test('adds .env to .gitignore', async () => {
 
   const gitignore = fs.readFileSync('.gitignore', 'utf8');
   expect(gitignore).toMatch('.env');
-});
-
-test('installs dotenv as a dev dependency', async () => {
-  vol.fromJSON(baseFiles, './');
-
-  await addEnv();
-
-  expect(exec).toHaveBeenCalledWith('yarn add --dev dotenv');
 });
 
 test('patches API file when it contains hardcoded URL', async () => {

--- a/src/commands/__tests__/notifications.test.ts
+++ b/src/commands/__tests__/notifications.test.ts
@@ -1,6 +1,6 @@
 import { confirm, input } from '@inquirer/prompts';
 import { fs, vol } from 'memfs';
-import { Mock, expect, test, vi } from 'vitest';
+import { Mock, afterEach, beforeEach, expect, test, vi } from 'vitest';
 import exec from '../../util/exec';
 import { addNotifications } from '../notifications';
 
@@ -12,21 +12,30 @@ vi.mock('@inquirer/prompts', () => ({
 }));
 vi.mock('../../util/exec');
 
+const baseFiles = {
+  'package.json': JSON.stringify({
+    scripts: {},
+    dependencies: {},
+    devDependencies: {},
+  }),
+  'yarn.lock': '',
+  'App.tsx': '// CODEGEN:BELT:HOOKS - do not remove',
+  'app.json': JSON.stringify({}),
+};
+
+beforeEach(() => {
+  (confirm as Mock).mockResolvedValueOnce(true);
+});
+
+afterEach(() => {
+  vol.reset();
+  vi.clearAllMocks();
+});
+
 test('install React Native Firebase and dependencies', async () => {
   (input as Mock).mockResolvedValueOnce('com.myapp');
   (input as Mock).mockResolvedValueOnce('com.myapp');
-  (confirm as Mock).mockResolvedValueOnce(true);
-  const json = {
-    'package.json': JSON.stringify({
-      scripts: {},
-      dependencies: {},
-      devDependencies: {},
-    }),
-    'yarn.lock': '',
-    'App.tsx': '// CODEGEN:BELT:HOOKS - do not remove',
-    'app.json': JSON.stringify({}),
-  };
-  vol.fromJSON(json, './');
+  vol.fromJSON(baseFiles, './');
 
   await addNotifications();
 
@@ -55,24 +64,20 @@ test('install React Native Firebase and dependencies', async () => {
 });
 
 test('add plugins to app.json expo config preserves existing ones', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
-  const json = {
-    'package.json': JSON.stringify({
-      scripts: {},
-      dependencies: {},
-      devDependencies: {},
-    }),
-    'yarn.lock': '',
-    'app.json': JSON.stringify({
-      expo: {
-        plugins: [
-          '@react-native-firebase/auth',
-          ['expo-build-properties', { config: 'test' }],
-        ],
-      },
-    }),
-  };
-  vol.fromJSON(json, './');
+  vol.fromJSON(
+    {
+      ...baseFiles,
+      'app.json': JSON.stringify({
+        expo: {
+          plugins: [
+            '@react-native-firebase/auth',
+            ['expo-build-properties', { config: 'test' }],
+          ],
+        },
+      }),
+    },
+    './',
+  );
 
   await addNotifications();
 
@@ -84,17 +89,7 @@ test('add plugins to app.json expo config preserves existing ones', async () => 
 });
 
 test('adds package name and bundle identifier from bundleId option', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
-  const json = {
-    'package.json': JSON.stringify({
-      scripts: {},
-      dependencies: {},
-      devDependencies: {},
-    }),
-    'yarn.lock': '',
-    'app.json': JSON.stringify({}),
-  };
-  vol.fromJSON(json, './');
+  vol.fromJSON(baseFiles, './');
 
   await addNotifications({ bundleId: 'com.myapp' });
 
@@ -104,26 +99,18 @@ test('adds package name and bundle identifier from bundleId option', async () =>
 });
 
 test('preserves existing package name and bundle identifier when bundleId is passed', async () => {
-  (confirm as Mock).mockResolvedValueOnce(true);
-  const json = {
-    'package.json': JSON.stringify({
-      scripts: {},
-      dependencies: {},
-      devDependencies: {},
-    }),
-    'yarn.lock': '',
-    'app.json': JSON.stringify({
-      expo: {
-        android: {
-          package: 'com.myexistingapp',
+  vol.fromJSON(
+    {
+      ...baseFiles,
+      'app.json': JSON.stringify({
+        expo: {
+          android: { package: 'com.myexistingapp' },
+          ios: { bundleIdentifier: 'com.myexistingapp' },
         },
-        ios: {
-          bundleIdentifier: 'com.myexistingapp',
-        },
-      },
-    }),
-  };
-  vol.fromJSON(json, './');
+      }),
+    },
+    './',
+  );
 
   await addNotifications({ bundleId: 'com.myapp' });
 

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -1,0 +1,149 @@
+import { confirm } from '@inquirer/prompts';
+import fs from 'fs-extra';
+import ora from 'ora';
+import path from 'path';
+import { globals } from '../constants';
+import addDependency from '../util/addDependency';
+import addToGitignore from '../util/addToGitignore';
+import commit from '../util/commit';
+import copyTemplate from '../util/copyTemplate';
+import getProjectDir from '../util/getProjectDir';
+import print from '../util/print';
+import writeFile from '../util/writeFile';
+
+type Options = {
+  interactive?: boolean;
+};
+
+const handleCommitError = (error: { stdout: string }) => {
+  if (!error.stdout.includes('nothing to commit')) {
+    throw error;
+  }
+};
+
+const API_PATH = 'src/util/api/api.ts';
+const HARDCODED_API_URL = "'https://api.github.com/orgs/thoughtbot/repos'";
+// eslint-disable-next-line no-template-curly-in-string
+const REPLACED_API_URL = "`${process.env.EXPO_PUBLIC_API_BASE_URL ?? ''}/orgs/thoughtbot/repos`";
+
+const JEST_CONFIG_PATH = 'jest.config.js';
+const JEST_SETUP_FILES_BEFORE = '  setupFilesAfterEnv: [';
+const JEST_SETUP_FILES_AFTER =
+  "  setupFiles: ['./jest.setup.env.js'],\n  setupFilesAfterEnv: [";
+
+export async function addEnv(options: Options = {}) {
+  const { interactive = true } = options;
+
+  globals.interactive = interactive;
+
+  await printIntro();
+
+  const spinner = ora().start('Setting up environment configuration');
+
+  const projectDir = await getProjectDir();
+
+  await addDependency('dotenv', { dev: true });
+
+  await copyTemplate({ templateDir: 'environments', templateFile: 'env.example', destination: '.env.example' });
+  await copyTemplate({ templateDir: 'environments', templateFile: 'src/config/index.ts' });
+  await copyTemplate({ templateDir: 'environments', templateFile: 'jest.setup.env.js' });
+  await copyTemplate({ templateDir: 'environments', templateFile: 'env.test', destination: '.env.test' });
+
+  const envPath = path.join(projectDir, '.env');
+  const envExists = await fs.pathExists(envPath);
+  if (!envExists) {
+    await fs.copy(path.join(projectDir, '.env.example'), envPath);
+  }
+
+  await addToGitignore('.env');
+
+  const apiFilePath = path.join(projectDir, API_PATH);
+  const apiFileExists = await fs.pathExists(apiFilePath);
+  let patchedApi = false;
+  if (apiFileExists) {
+    const contents = (await fs.readFile(apiFilePath)).toString();
+    const updated = contents.replace(HARDCODED_API_URL, REPLACED_API_URL);
+    if (updated !== contents) {
+      await writeFile(apiFilePath, updated, { format: true });
+      patchedApi = true;
+    }
+  }
+
+  const jestConfigPath = path.join(projectDir, JEST_CONFIG_PATH);
+  const jestConfigExists = await fs.pathExists(jestConfigPath);
+  let patchedJest = false;
+  if (jestConfigExists) {
+    const contents = (await fs.readFile(jestConfigPath)).toString();
+    const updated = contents.replace(
+      JEST_SETUP_FILES_BEFORE,
+      JEST_SETUP_FILES_AFTER,
+    );
+    if (updated !== contents) {
+      await writeFile(jestConfigPath, updated, { format: true });
+      patchedJest = true;
+    }
+  }
+
+  await commit('Add environment variable management support.').catch(
+    handleCommitError,
+  );
+
+  spinner.succeed(`Successfully set up environment variable management!
+
+  What was added:
+  - .env.example: Template of environment variables (committed to git)
+  - .env: Your local environment variables (gitignored)
+  - .env.test: Environment variables for Jest (committed to git)
+  - jest.setup.env.js: Loads .env.test before tests run
+  - src/config/index.ts: Typed helper to access config values in your app${
+    patchedApi ? `\n  - ${API_PATH}: Updated to use EXPO_PUBLIC_API_BASE_URL` : ''
+  }${
+    patchedJest
+      ? `\n  - ${JEST_CONFIG_PATH}: Added setupFiles to load jest.setup.env.js`
+      : ''
+  }
+
+  Usage in your app:
+    import getConfig from 'src/config';
+    const { apiBaseUrl } = getConfig();
+
+  Variables prefixed with EXPO_PUBLIC_ are automatically loaded by the Expo CLI
+  and inlined into your app bundle — no dotenv or extra config required.
+
+  These values are visible in plain text in the compiled app.
+  Never store secrets as EXPO_PUBLIC_ variables.
+  `);
+}
+
+async function printIntro() {
+  print("Let's set up environment variable management!");
+  print(`
+  We will configure your Expo app to handle environment variables using the
+  built-in EXPO_PUBLIC_ mechanism. This includes:
+
+  - .env.example: Template showing your environment variables (committed)
+  - .env: Your local values (gitignored)
+  - .env.test: Environment variables for Jest tests (committed)
+  - jest.setup.env.js: Loads .env.test before each test run
+  - src/config/index.ts: Typed helper for safe config access
+
+  Variables prefixed with EXPO_PUBLIC_ are automatically loaded by the Expo CLI
+  and inlined into the app bundle at build time. No extra packages needed.
+  `);
+
+  if (!globals.interactive) {
+    return;
+  }
+
+  const proceed = await confirm({ message: 'Ready to proceed?' });
+  if (!proceed) {
+    process.exit(0);
+  }
+
+  print('');
+}
+
+export default function addEnvAction(...args: unknown[]) {
+  const options = (args[0] as unknown[])[0] as Options;
+  return addEnv(options);
+}

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { globals } from '../constants';
 import addDependency from '../util/addDependency';
 import addToGitignore from '../util/addToGitignore';
-import commit from '../util/commit';
+import commit, { handleCommitError } from '../util/commit';
 import copyTemplate from '../util/copyTemplate';
 import getProjectDir from '../util/getProjectDir';
 import print from '../util/print';
@@ -13,12 +13,6 @@ import writeFile from '../util/writeFile';
 
 type Options = {
   interactive?: boolean;
-};
-
-const handleCommitError = (error: { stdout: string }) => {
-  if (!error.stdout.includes('nothing to commit')) {
-    throw error;
-  }
 };
 
 const API_PATH = 'src/util/api/api.ts';
@@ -31,6 +25,19 @@ const JEST_CONFIG_PATH = 'jest.config.js';
 const JEST_SETUP_FILES_BEFORE = '  setupFilesAfterEnv: [';
 const JEST_SETUP_FILES_AFTER =
   "  setupFiles: ['./jest.setup.env.js'],\n  setupFilesAfterEnv: [";
+
+async function patchFile(
+  filePath: string,
+  search: string,
+  replacement: string,
+): Promise<boolean> {
+  if (!(await fs.pathExists(filePath))) return false;
+  const contents = (await fs.readFile(filePath)).toString();
+  const updated = contents.replace(search, replacement);
+  if (updated === contents) return false;
+  await writeFile(filePath, updated, { format: true });
+  return true;
+}
 
 export async function addEnv(options: Options = {}) {
   const { interactive = true } = options;
@@ -65,39 +72,22 @@ export async function addEnv(options: Options = {}) {
   });
 
   const envPath = path.join(projectDir, '.env');
-  const envExists = await fs.pathExists(envPath);
-  if (!envExists) {
+  if (!(await fs.pathExists(envPath))) {
     await fs.copy(path.join(projectDir, '.env.example'), envPath);
   }
 
   await addToGitignore('.env');
 
-  const apiFilePath = path.join(projectDir, API_PATH);
-  const apiFileExists = await fs.pathExists(apiFilePath);
-  let patchedApi = false;
-  if (apiFileExists) {
-    const contents = (await fs.readFile(apiFilePath)).toString();
-    const updated = contents.replace(HARDCODED_API_URL, REPLACED_API_URL);
-    if (updated !== contents) {
-      await writeFile(apiFilePath, updated, { format: true });
-      patchedApi = true;
-    }
-  }
-
-  const jestConfigPath = path.join(projectDir, JEST_CONFIG_PATH);
-  const jestConfigExists = await fs.pathExists(jestConfigPath);
-  let patchedJest = false;
-  if (jestConfigExists) {
-    const contents = (await fs.readFile(jestConfigPath)).toString();
-    const updated = contents.replace(
-      JEST_SETUP_FILES_BEFORE,
-      JEST_SETUP_FILES_AFTER,
-    );
-    if (updated !== contents) {
-      await writeFile(jestConfigPath, updated, { format: true });
-      patchedJest = true;
-    }
-  }
+  const patchedApi = await patchFile(
+    path.join(projectDir, API_PATH),
+    HARDCODED_API_URL,
+    REPLACED_API_URL,
+  );
+  const patchedJest = await patchFile(
+    path.join(projectDir, JEST_CONFIG_PATH),
+    JEST_SETUP_FILES_BEFORE,
+    JEST_SETUP_FILES_AFTER,
+  );
 
   await commit('Add environment variable management support.').catch(
     handleCommitError,

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -1,4 +1,3 @@
-import { confirm } from '@inquirer/prompts';
 import fs from 'fs-extra';
 import ora from 'ora';
 import path from 'path';
@@ -6,94 +5,43 @@ import { globals } from '../constants';
 import addDependency from '../util/addDependency';
 import addToGitignore from '../util/addToGitignore';
 import commit, { handleCommitError } from '../util/commit';
+import confirmToProceed from '../util/confirmToProceed';
 import copyTemplate from '../util/copyTemplate';
 import getProjectDir from '../util/getProjectDir';
-import print from '../util/print';
-import writeFile from '../util/writeFile';
+import patchFile from '../util/patchFile';
 
 type Options = {
   interactive?: boolean;
 };
 
 const API_PATH = 'src/util/api/api.ts';
-const HARDCODED_API_URL = "'https://api.github.com/orgs/thoughtbot/repos'";
-const REPLACED_API_URL =
+const API_URL_SEARCH = "'https://api.github.com/orgs/thoughtbot/repos'";
+const API_URL_REPLACEMENT =
   // eslint-disable-next-line no-template-curly-in-string
   "`${process.env.EXPO_PUBLIC_API_BASE_URL ?? ''}/orgs/thoughtbot/repos`";
 
 const JEST_CONFIG_PATH = 'jest.config.js';
-const JEST_SETUP_FILES_BEFORE = '  setupFilesAfterEnv: [';
-const JEST_SETUP_FILES_AFTER =
+const JEST_SETUP_SEARCH = '  setupFilesAfterEnv: [';
+const JEST_SETUP_REPLACEMENT =
   "  setupFiles: ['./jest.setup.env.js'],\n  setupFilesAfterEnv: [";
 
-async function patchFile(
-  filePath: string,
-  search: string,
-  replacement: string,
-): Promise<boolean> {
-  if (!(await fs.pathExists(filePath))) return false;
-  const contents = (await fs.readFile(filePath)).toString();
-  const updated = contents.replace(search, replacement);
-  if (updated === contents) return false;
-  await writeFile(filePath, updated, { format: true });
-  return true;
-}
+const INTRO_MESSAGE = `Let's set up environment variable management!
 
-export async function addEnv(options: Options = {}) {
-  const { interactive = true } = options;
+  We will configure your Expo app to handle environment variables using the
+  built-in EXPO_PUBLIC_ mechanism. This includes:
 
-  globals.interactive = interactive;
+  - .env.example: Template showing your environment variables (committed)
+  - .env: Your local values (gitignored)
+  - .env.test: Environment variables for Jest tests (committed)
+  - jest.setup.env.js: Loads .env.test before each test run
+  - src/config/index.ts: Typed helper for safe config access
 
-  await printIntro();
+  Variables prefixed with EXPO_PUBLIC_ are automatically loaded by the Expo CLI
+  and inlined into the app bundle at build time. No extra packages needed.
+  `;
 
-  const spinner = ora().start('Setting up environment configuration');
-
-  const projectDir = await getProjectDir();
-
-  await addDependency('dotenv', { dev: true });
-
-  await copyTemplate({
-    templateDir: 'environments',
-    templateFile: 'env.example',
-    destination: '.env.example',
-  });
-  await copyTemplate({
-    templateDir: 'environments',
-    templateFile: 'src/config/index.ts',
-  });
-  await copyTemplate({
-    templateDir: 'environments',
-    templateFile: 'jest.setup.env.js',
-  });
-  await copyTemplate({
-    templateDir: 'environments',
-    templateFile: 'env.test',
-    destination: '.env.test',
-  });
-
-  const envPath = path.join(projectDir, '.env');
-  if (!(await fs.pathExists(envPath))) {
-    await fs.copy(path.join(projectDir, '.env.example'), envPath);
-  }
-
-  await addToGitignore('.env');
-
-  const patchedApi = await patchFile(
-    path.join(projectDir, API_PATH),
-    HARDCODED_API_URL,
-    REPLACED_API_URL,
-  );
-  const patchedJest = await patchFile(
-    path.join(projectDir, JEST_CONFIG_PATH),
-    JEST_SETUP_FILES_BEFORE,
-    JEST_SETUP_FILES_AFTER,
-  );
-
-  await commit('Add environment variable management support.').catch(
-    handleCommitError,
-  );
-
-  spinner.succeed(`Successfully set up environment variable management!
+function successMessage(patchedApi: boolean, patchedJest: boolean) {
+  return `Successfully set up environment variable management!
 
   What was added:
   - .env.example: Template of environment variables (committed to git)
@@ -119,38 +67,73 @@ export async function addEnv(options: Options = {}) {
 
   These values are visible in plain text in the compiled app.
   Never store secrets as EXPO_PUBLIC_ variables.
-  `);
+  `;
 }
 
-async function printIntro() {
-  print("Let's set up environment variable management!");
-  print(`
-  We will configure your Expo app to handle environment variables using the
-  built-in EXPO_PUBLIC_ mechanism. This includes:
+export async function addEnv(options: Options = {}) {
+  const { interactive = true } = options;
 
-  - .env.example: Template showing your environment variables (committed)
-  - .env: Your local values (gitignored)
-  - .env.test: Environment variables for Jest tests (committed)
-  - jest.setup.env.js: Loads .env.test before each test run
-  - src/config/index.ts: Typed helper for safe config access
+  globals.interactive = interactive;
 
-  Variables prefixed with EXPO_PUBLIC_ are automatically loaded by the Expo CLI
-  and inlined into the app bundle at build time. No extra packages needed.
-  `);
+  await confirmToProceed(INTRO_MESSAGE);
 
-  if (!globals.interactive) {
-    return;
+  const spinner = ora().start('Setting up environment configuration');
+
+  try {
+    const projectDir = await getProjectDir();
+
+    await addDependency('dotenv', { dev: true });
+
+    await copyTemplate({
+      templateDir: 'environments',
+      templateFile: 'env.example',
+      destination: '.env.example',
+    });
+    await copyTemplate({
+      templateDir: 'environments',
+      templateFile: 'src/config/index.ts',
+    });
+    await copyTemplate({
+      templateDir: 'environments',
+      templateFile: 'jest.setup.env.js',
+    });
+    await copyTemplate({
+      templateDir: 'environments',
+      templateFile: 'env.test',
+      destination: '.env.test',
+    });
+
+    const envPath = path.join(projectDir, '.env');
+    if (!(await fs.pathExists(envPath))) {
+      await fs.copy(path.join(projectDir, '.env.example'), envPath);
+    }
+
+    await addToGitignore('.env');
+
+    const patchedApi = await patchFile(
+      path.join(projectDir, API_PATH),
+      API_URL_SEARCH,
+      API_URL_REPLACEMENT,
+    );
+    const patchedJest = await patchFile(
+      path.join(projectDir, JEST_CONFIG_PATH),
+      JEST_SETUP_SEARCH,
+      JEST_SETUP_REPLACEMENT,
+    );
+
+    await commit('Add environment variable management support.').catch(
+      handleCommitError,
+    );
+
+    spinner.succeed(successMessage(patchedApi, patchedJest));
+  } catch (error) {
+    spinner.fail((error as Error).message);
+    throw error;
   }
-
-  const proceed = await confirm({ message: 'Ready to proceed?' });
-  if (!proceed) {
-    process.exit(0);
-  }
-
-  print('');
 }
 
 export default function addEnvAction(...args: unknown[]) {
+  // Commander passes ([<Options hash>, <Command>]) as args
   const options = (args[0] as unknown[])[0] as Options;
   return addEnv(options);
 }

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -2,7 +2,6 @@ import fs from 'fs-extra';
 import ora from 'ora';
 import path from 'path';
 import { globals } from '../constants';
-import addDependency from '../util/addDependency';
 import addToGitignore from '../util/addToGitignore';
 import commit, { handleCommitError } from '../util/commit';
 import confirmToProceed from '../util/confirmToProceed';
@@ -32,8 +31,7 @@ const INTRO_MESSAGE = `Let's set up environment variable management!
 
   - .env.example: Template showing your environment variables (committed)
   - .env: Your local values (gitignored)
-  - .env.test: Environment variables for Jest tests (committed)
-  - jest.setup.env.js: Loads .env.test before each test run
+  - jest.setup.env.js: Sets test environment variables before each test run
   - src/config/index.ts: Typed helper for safe config access
 
   Variables prefixed with EXPO_PUBLIC_ are automatically loaded by the Expo CLI
@@ -46,8 +44,7 @@ function successMessage(patchedApi: boolean, patchedJest: boolean) {
   What was added:
   - .env.example: Template of environment variables (committed to git)
   - .env: Your local environment variables (gitignored)
-  - .env.test: Environment variables for Jest (committed to git)
-  - jest.setup.env.js: Loads .env.test before tests run
+  - jest.setup.env.js: Sets test environment variables before tests run
   - src/config/index.ts: Typed helper to access config values in your app${
     patchedApi
       ? `\n  - ${API_PATH}: Updated to use EXPO_PUBLIC_API_BASE_URL`
@@ -82,8 +79,6 @@ export async function addEnv(options: Options = {}) {
   try {
     const projectDir = await getProjectDir();
 
-    await addDependency('dotenv', { dev: true });
-
     await copyTemplate({
       templateDir: 'environments',
       templateFile: 'env.example',
@@ -96,11 +91,6 @@ export async function addEnv(options: Options = {}) {
     await copyTemplate({
       templateDir: 'environments',
       templateFile: 'jest.setup.env.js',
-    });
-    await copyTemplate({
-      templateDir: 'environments',
-      templateFile: 'env.test',
-      destination: '.env.test',
     });
 
     const envPath = path.join(projectDir, '.env');

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -23,8 +23,9 @@ const handleCommitError = (error: { stdout: string }) => {
 
 const API_PATH = 'src/util/api/api.ts';
 const HARDCODED_API_URL = "'https://api.github.com/orgs/thoughtbot/repos'";
-// eslint-disable-next-line no-template-curly-in-string
-const REPLACED_API_URL = "`${process.env.EXPO_PUBLIC_API_BASE_URL ?? ''}/orgs/thoughtbot/repos`";
+const REPLACED_API_URL =
+  // eslint-disable-next-line no-template-curly-in-string
+  "`${process.env.EXPO_PUBLIC_API_BASE_URL ?? ''}/orgs/thoughtbot/repos`";
 
 const JEST_CONFIG_PATH = 'jest.config.js';
 const JEST_SETUP_FILES_BEFORE = '  setupFilesAfterEnv: [';
@@ -44,10 +45,24 @@ export async function addEnv(options: Options = {}) {
 
   await addDependency('dotenv', { dev: true });
 
-  await copyTemplate({ templateDir: 'environments', templateFile: 'env.example', destination: '.env.example' });
-  await copyTemplate({ templateDir: 'environments', templateFile: 'src/config/index.ts' });
-  await copyTemplate({ templateDir: 'environments', templateFile: 'jest.setup.env.js' });
-  await copyTemplate({ templateDir: 'environments', templateFile: 'env.test', destination: '.env.test' });
+  await copyTemplate({
+    templateDir: 'environments',
+    templateFile: 'env.example',
+    destination: '.env.example',
+  });
+  await copyTemplate({
+    templateDir: 'environments',
+    templateFile: 'src/config/index.ts',
+  });
+  await copyTemplate({
+    templateDir: 'environments',
+    templateFile: 'jest.setup.env.js',
+  });
+  await copyTemplate({
+    templateDir: 'environments',
+    templateFile: 'env.test',
+    destination: '.env.test',
+  });
 
   const envPath = path.join(projectDir, '.env');
   const envExists = await fs.pathExists(envPath);
@@ -96,7 +111,9 @@ export async function addEnv(options: Options = {}) {
   - .env.test: Environment variables for Jest (committed to git)
   - jest.setup.env.js: Loads .env.test before tests run
   - src/config/index.ts: Typed helper to access config values in your app${
-    patchedApi ? `\n  - ${API_PATH}: Updated to use EXPO_PUBLIC_API_BASE_URL` : ''
+    patchedApi
+      ? `\n  - ${API_PATH}: Updated to use EXPO_PUBLIC_API_BASE_URL`
+      : ''
   }${
     patchedJest
       ? `\n  - ${JEST_CONFIG_PATH}: Added setupFiles to load jest.setup.env.js`

--- a/src/commands/notifications.ts
+++ b/src/commands/notifications.ts
@@ -2,7 +2,7 @@ import { confirm, input } from '@inquirer/prompts';
 import ora from 'ora';
 import { globals } from '../constants';
 import addExpoConfig from '../util/addExpoConfig';
-import commit from '../util/commit';
+import commit, { handleCommitError } from '../util/commit';
 import copyTemplateDirectory from '../util/copyTemplateDirectory';
 import exec from '../util/exec';
 import injectHooks from '../util/injectHooks';
@@ -12,12 +12,6 @@ import readAppJson from '../util/readAppJson';
 type Options = {
   bundleId?: string;
   interactive?: boolean;
-};
-
-const handleCommitError = (error: { stdout: string }) => {
-  if (!error.stdout.includes('nothing to commit')) {
-    throw error;
-  }
 };
 
 export async function addNotifications(options: Options = {}) {

--- a/src/commands/notifications.ts
+++ b/src/commands/notifications.ts
@@ -1,18 +1,39 @@
-import { confirm, input } from '@inquirer/prompts';
+import { input } from '@inquirer/prompts';
 import ora from 'ora';
 import { globals } from '../constants';
 import addExpoConfig from '../util/addExpoConfig';
 import commit, { handleCommitError } from '../util/commit';
+import confirmToProceed from '../util/confirmToProceed';
 import copyTemplateDirectory from '../util/copyTemplateDirectory';
 import exec from '../util/exec';
 import injectHooks from '../util/injectHooks';
-import print from '../util/print';
 import readAppJson from '../util/readAppJson';
 
 type Options = {
   bundleId?: string;
   interactive?: boolean;
 };
+
+const INTRO_MESSAGE = `Let's get started!
+
+  We will now add notifications support to your app. This will include the following changes:
+
+  - Add React Native Firebase, Messaging and Expo Build Properties dependencies
+  - Add notification handlers to your app
+  - Configure your app.json file with the necessary information
+
+  NOTE: React Native Firebase cannot be used in the pre-compiled Expo Go app because React Native Firebase uses native code that is not compiled into Expo Go. This will switch the app build process to use Continuos Native Generation (CGN), for more details please refer to the documentation (https://docs.expo.dev/workflow/continuous-native-generation).
+  `;
+
+const SUCCESS_MESSAGE = `Successfully added notifications support to project.
+
+  In order to finish the setup please complete the following steps:
+  - Add your google-service.json and GoogleService-Info.plist files to your project's config folder
+  - Run the command "npx expo prebuild --clean" to rebuild the app
+  - Add the ios/ and android/ folders to your .gitignore file if you don't need to track them
+
+  For more details please refer to the official documentation: https://rnfirebase.io/#configure-react-native-firebase-modules.
+  `;
 
 export async function addNotifications(options: Options = {}) {
   const { interactive = true } = options;
@@ -21,111 +42,81 @@ export async function addNotifications(options: Options = {}) {
 
   const { bundleId = !interactive ? 'com.myapp' : undefined } = options;
 
-  await printIntro();
+  await confirmToProceed(INTRO_MESSAGE);
 
   const spinner = ora().start('Adding React Native Firebase and dependencies');
 
-  // Install dependencies
-  await exec(
-    'npx expo install @react-native-firebase/app @react-native-firebase/messaging expo-build-properties',
-  );
+  try {
+    await exec(
+      'npx expo install @react-native-firebase/app @react-native-firebase/messaging expo-build-properties',
+    );
 
-  spinner.succeed('Added React Native Firebase and dependencies');
+    spinner.succeed('Added React Native Firebase and dependencies');
 
-  spinner.start('Adding notification handlers');
+    spinner.start('Adding notification handlers');
 
-  await copyTemplateDirectory({
-    templateDir: 'notifications',
-  });
+    await copyTemplateDirectory({
+      templateDir: 'notifications',
+    });
 
-  await injectHooks(
-    'App.tsx',
-    'useNotifications();',
-    "import useNotifications from 'src/hooks/useNotifications';\n",
-  );
+    await injectHooks(
+      'App.tsx',
+      'useNotifications();',
+      "import useNotifications from 'src/hooks/useNotifications';\n",
+    );
 
-  spinner.succeed('Added notification handlers');
+    spinner.succeed('Added notification handlers');
 
-  // Verify for bundle identifier and package name in the AppJsonConfig
-  const appJson = await readAppJson();
+    const appJson = await readAppJson();
 
-  const packageName =
-    appJson.expo?.android?.package ??
-    bundleId ??
-    (await input({
-      message: 'Define your Android package name:',
-      default: 'com.myapp',
-    }));
+    const packageName =
+      appJson.expo?.android?.package ??
+      bundleId ??
+      (await input({
+        message: 'Define your Android package name:',
+        default: 'com.myapp',
+      }));
 
-  const bundleIdentifier =
-    appJson.expo?.ios?.bundleIdentifier ??
-    bundleId ??
-    (await input({
-      message: 'Define your iOS bundle identifier:',
-      default: packageName,
-    }));
+    const bundleIdentifier =
+      appJson.expo?.ios?.bundleIdentifier ??
+      bundleId ??
+      (await input({
+        message: 'Define your iOS bundle identifier:',
+        default: packageName,
+      }));
 
-  spinner.start('Configuring app.json');
+    spinner.start('Configuring app.json');
 
-  await addExpoConfig({
-    android: {
-      googleServicesFile: './config/google-services.json',
-      package: packageName,
-    },
-    ios: {
-      googleServicesFile: './config/GoogleService-Info.plist',
-      bundleIdentifier,
-    },
-    plugins: [
-      '@react-native-firebase/app',
-      '@react-native-firebase/messaging',
-      [
-        'expo-build-properties',
-        {
-          ios: {
-            useFrameworks: 'static',
+    await addExpoConfig({
+      android: {
+        googleServicesFile: './config/google-services.json',
+        package: packageName,
+      },
+      ios: {
+        googleServicesFile: './config/GoogleService-Info.plist',
+        bundleIdentifier,
+      },
+      plugins: [
+        '@react-native-firebase/app',
+        '@react-native-firebase/messaging',
+        [
+          'expo-build-properties',
+          {
+            ios: {
+              useFrameworks: 'static',
+            },
           },
-        },
+        ],
       ],
-    ],
-  });
+    });
 
-  await commit('Add push notifications support.').catch(handleCommitError);
+    await commit('Add push notifications support.').catch(handleCommitError);
 
-  spinner.succeed(
-    `Successfully added notifications support to project.
-
-  In order to finish the setup please complete the following steps:
-  - Add your google-service.json and GoogleService-Info.plist files to your project's config folder
-  - Run the command "npx expo prebuild --clean" to rebuild the app
-  - Add the ios/ and android/ folders to your .gitignore file if you don't need to track them
-
-  For more details please refer to the official documentation: https://rnfirebase.io/#configure-react-native-firebase-modules.
-  `,
-  );
-}
-
-async function printIntro() {
-  print('Let’s get started!');
-  print(`\nWe will now add notifications support to your app. This will include the following changes:
-
-  - Add React Native Firebase, Messaging and Expo Build Properties dependencies
-  - Add notification handlers to your app
-  - Configure your app.json file with the necessary information
-
-  NOTE: React Native Firebase cannot be used in the pre-compiled Expo Go app because React Native Firebase uses native code that is not compiled into Expo Go. This will switch the app build process to use Continuos Native Generation (CGN), for more details please refer to the documentation (https://docs.expo.dev/workflow/continuous-native-generation).
-  `);
-
-  if (!globals.interactive) {
-    return;
+    spinner.succeed(SUCCESS_MESSAGE);
+  } catch (error) {
+    spinner.fail((error as Error).message);
+    throw error;
   }
-
-  const proceed = await confirm({ message: 'Ready to proceed?' });
-  if (!proceed) {
-    process.exit(0);
-  }
-
-  print(''); // add new line
 }
 
 /**

--- a/src/util/commit.ts
+++ b/src/util/commit.ts
@@ -4,3 +4,9 @@ export default async function commit(message: string) {
   await exec('git add .');
   await exec(`git commit -m "${message}"`);
 }
+
+export function handleCommitError(error: { stdout: string }) {
+  if (!error.stdout.includes('nothing to commit')) {
+    throw error;
+  }
+}

--- a/src/util/confirmToProceed.ts
+++ b/src/util/confirmToProceed.ts
@@ -1,0 +1,11 @@
+import { confirm } from '@inquirer/prompts';
+import { globals } from '../constants';
+import print from './print';
+
+export default async function confirmToProceed(message: string): Promise<void> {
+  print(message);
+  if (!globals.interactive) return;
+  const proceed = await confirm({ message: 'Ready to proceed?' });
+  if (!proceed) process.exit(0);
+  print('');
+}

--- a/src/util/patchFile.ts
+++ b/src/util/patchFile.ts
@@ -1,0 +1,15 @@
+import fs from 'fs-extra';
+import writeFile from './writeFile';
+
+export default async function patchFile(
+  filePath: string,
+  search: string,
+  replacement: string,
+): Promise<boolean> {
+  if (!(await fs.pathExists(filePath))) return false;
+  const contents = (await fs.readFile(filePath)).toString();
+  const updated = contents.replace(search, replacement);
+  if (updated === contents) return false;
+  await writeFile(filePath, updated, { format: true });
+  return true;
+}

--- a/templates/environments/env.example
+++ b/templates/environments/env.example
@@ -1,0 +1,8 @@
+# Environment Variables
+# Copy this file to .env and fill in your values.
+# Only .env.example is committed to version control — never commit .env.
+
+# Variables prefixed with EXPO_PUBLIC_ are automatically loaded by the Expo CLI
+# and inlined into your app bundle at build time. They are visible in plain text
+# in the compiled app — never store secrets here.
+EXPO_PUBLIC_API_BASE_URL=https://api.github.com

--- a/templates/environments/env.test
+++ b/templates/environments/env.test
@@ -1,1 +1,0 @@
-EXPO_PUBLIC_API_BASE_URL=https://api.github.com

--- a/templates/environments/env.test
+++ b/templates/environments/env.test
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL=https://api.github.com

--- a/templates/environments/jest.setup.env.js
+++ b/templates/environments/jest.setup.env.js
@@ -1,0 +1,2 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+require('dotenv').config({ path: '.env.test' });

--- a/templates/environments/jest.setup.env.js
+++ b/templates/environments/jest.setup.env.js
@@ -1,2 +1,1 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-require('dotenv').config({ path: '.env.test' });
+process.env.EXPO_PUBLIC_API_BASE_URL = 'https://api.github.com';

--- a/templates/environments/src/config/index.ts
+++ b/templates/environments/src/config/index.ts
@@ -1,0 +1,11 @@
+interface Config {
+  apiBaseUrl: string;
+}
+
+export default function getConfig(): Config {
+  return {
+    // process.env.EXPO_PUBLIC_* variables are inlined at build time by the Expo bundler.
+    // Always use dot notation — bracket notation and destructuring are not supported.
+    apiBaseUrl: process.env.EXPO_PUBLIC_API_BASE_URL ?? '',
+  };
+}


### PR DESCRIPTION
In this PR, we add a new `belt add env` CLI command that sets up [environment variable management](https://docs.expo.dev/guides/environment-variables/) in an Expo project using the `EXPO_PUBLIC_` mechanism.

## What the command does
- Installs `dotenv` as a dev dependency.
- Copies template files: `.env.example`, `.env.test`, `jest.setup.env.js`, and `src/config/index.ts`.
- Creates `.env` from `.env.example` if it doesn't already exist.
- Patches `src/util/api/api.ts` to replace the hardcoded GitHub API URL with `EXPO_PUBLIC_API_BASE_URL`.
- Patches `jest.config.js` to load `jest.setup.env.js` via `setupFiles`.

## Refactoring existing notifications code

Reusable utilities were extracted as part of this work and applied to both env and notifications:
- `src/util/patchFile.ts` - generic read/search/replace/write function to patch existing project files.
- `src/util/confirmToProceed.ts` - interactive intro prompt shared across commands.
- `handleCommitError` moved to be used in multiple commands.

Both env and notifications command now have:
- Improved error handling using a try/catch with spinner.fail(error.message) so the terminal doesn't hang on errors.
- Multi-line user facing strings extracted to named constants for better readability of the code
